### PR TITLE
source stage1+2 functions from KOPS_INSTALLER/*

### DIFF
--- a/k8s/install/etc/config.sh.template
+++ b/k8s/install/etc/config.sh.template
@@ -13,6 +13,7 @@ export KOPS_K8S_VERSION="1.5.2"
 # s3 buckets
 export TF_STATE_BUCKET="${KOPS_SHORT_NAME}-tf-state"
 export KOPS_STATE_BUCKET="${KOPS_SHORT_NAME}-kops-state"
+export KOPS_STATE_STORE="s3://${KOPS_STATE_BUCKET}"
 
 # populate these if installing FluentD->PaperTrail DaemonSet
 export SYSLOG_HOST=""

--- a/k8s/install/stage1.sh
+++ b/k8s/install/stage1.sh
@@ -18,7 +18,7 @@ if [ -z "${KOPS_INSTALLER}" ]; then
     exit -1
 fi
 
-source stage1_functions.sh
+source ${KOPS_INSTALLER}/stage1_functions.sh
 
 verify_env
 run_kops

--- a/k8s/install/stage2.sh
+++ b/k8s/install/stage2.sh
@@ -18,7 +18,7 @@ then
 	exit 1
 fi
 
-source stage2_functions.sh
+source ${KOPS_INSTALLER}/stage2_functions.sh
 
 install_deps
 install_tiller


### PR DESCRIPTION
- I renamed `KOPS_STATE_STORE` to `KOPS_STATE_BUCKET`, but we actually need both. One with the `s3://` prefix, and one without.