### PR TITLE
change ELB timeout after configuring ELB ssl

### DIFF
--- a/k8s/install/stage2.sh
+++ b/k8s/install/stage2.sh
@@ -35,9 +35,9 @@ if [ "${INSTALL_FLUENTD}" -eq 1 ]; then install_fluentd; fi
 
 if [ "${INSTALL_WORKFLOW}" -eq 1 ]; then
     install_workflow
-    config_deis_elb
     config_deis_dns
     config_elb_ssl
+    config_deis_elb_timeout
 fi
 
 


### PR DESCRIPTION
- moves the ELB timeout change to run after the SSL change
- renamed `config_deis_elb` to `config_deis_elb_timeout`
- reordered functions to reflect calling order.