### PR TITLE
Deis DNS via k8s annotation, run stage2 from dir with config.sh instead of out/terraform, misc

### DIFF
--- a/k8s/install/README.md
+++ b/k8s/install/README.md
@@ -52,13 +52,14 @@ kubectl get nodes
 
 ### Installing monitoring services
 
-This step installs Mig, Datadog, New Relic DaemonSets, the k8s dashboard, and Deis Workflow. 
+This step installs Mig, Datadog, New Relic DaemonSets, the k8s dashboard, and Deis Workflow.
 
 You'll need to:
 
-0. clone and **unlock** the `ee-infra-private` repo 
+0. clone and **unlock** the `ee-infra-private` repo
 1. modify `config.sh` and set `STAGE2_ETC_PATH` to point to the `ee-infra-private/k8s/install/etc` directory.
-2. run: `$KOPS_INSTALLER/stage2.sh`
+2. cd to the directory containing config.sh
+3. run: `$KOPS_INSTALLER/stage2.sh`
 
 Note: each DaemonSet is installed into it's own namespace: `mig`, `datadog`, `newrelic`, and `deis`.
 

--- a/k8s/install/stage2.sh
+++ b/k8s/install/stage2.sh
@@ -10,12 +10,9 @@ if [ -z "${STAGE2_ETC_PATH}" ]; then
 	exit -1
 fi
 
-# let's make sure we are in the right directory
-terraform output region > /dev/null 2>&1
-if [ $? -ne 0 ]
-then
-	echo "Please run from <mycluster>/out/terraform directory"
-	exit 1
+if [ ! -f config.sh ]; then
+    echo "Can't find config.sh in cwd"
+    exit -1
 fi
 
 source ${KOPS_INSTALLER}/stage2_functions.sh

--- a/k8s/install/stage2_functions.sh
+++ b/k8s/install/stage2_functions.sh
@@ -1,170 +1,184 @@
+# are we running from a directory with config.sh?
+check_cwd() {
+    if [ ! -f config.sh ]; then
+        echo "Can't find config.sh in cwd"
+        exit 1
+    fi
+}
+
 install_y2j() {
-	which y2j > /dev/null
-	if [ $? -ne 0 ]; then
-		echo "Installing y2j"
-		sudo docker run --rm wildducktheories/y2j y2j.sh installer /usr/local/bin | sudo bash
-	else
-		echo "y2j already installed"
-	fi
+    which y2j > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Installing y2j"
+        sudo docker run --rm wildducktheories/y2j y2j.sh installer /usr/local/bin | sudo bash
+    else
+        echo "y2j already installed"
+    fi
 }
 
 install_kubectl() {
-	which kubectl > /dev/null
-	if [ $? -ne 0 ]; then
-		echo "Installing kubectl"
-		curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-		chmod +x ./kubectl
-		sudo mv ./kubectl /usr/local/bin/kubectl
-	else
-		echo "kubectl already installed"
-	fi
+    which kubectl > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Installing kubectl"
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+    else
+        echo "kubectl already installed"
+    fi
 }
 
 install_helm() {
-	echo "Downloading helm"
-	which helm > /dev/null
-	if [ $? -ne 0 ]; then
-		echo "Installing helm client"
-		(cd /tmp && \
-			wget https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
-			tar xzf /tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
-			sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm)
-		  echo "Done installing helm client"
-	fi
+    echo "Downloading helm"
+    which helm > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Installing helm client"
+        (cd /tmp && \
+            wget https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
+            tar xzf /tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
+            sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm)
+          echo "Done installing helm client"
+    fi
 }
 
 install_deis_client() {
-	which deis > /dev/null
-	if [ $? -ne 0 ]; then
-		echo "Installing deis cli"
-		curl -o deis https://storage.googleapis.com/workflow-cli-master/deis-latest-linux-amd64
-		chmod +x deis
-		sudo mv ./deis /usr/local/bin/deis
-	else
-		echo "Deis cli already installed"
-	fi
+    which deis > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Installing deis cli"
+        curl -o deis https://storage.googleapis.com/workflow-cli-master/deis-latest-linux-amd64
+        chmod +x deis
+        sudo mv ./deis /usr/local/bin/deis
+    else
+        echo "Deis cli already installed"
+    fi
 }
 
 install_deps() {
-	install_y2j
-	install_kubectl
-	install_helm
-	install_deis_client
+    install_y2j
+    install_kubectl
+    install_helm
+    install_deis_client
 }
 
 install_mig() {
-	echo "Installing mig"
-	kubectl create namespace mig | true
-	kubectl -n mig create secret generic mig-agent-secrets \
-		--from-file=${STAGE2_ETC_PATH}/agent.key \
-		--from-file=${STAGE2_ETC_PATH}/agent.crt \
-		--from-file=${STAGE2_ETC_PATH}/ca.crt \
-		--from-file=${STAGE2_ETC_PATH}/mqpassword \
-		--from-file=${STAGE2_ETC_PATH}/mig-agent.cfg
-	kubectl -n mig create -f ${STAGE2_ETC_PATH}/migdaemonset.yaml
+    echo "Installing mig"
+    kubectl create namespace mig | true
+    kubectl -n mig create secret generic mig-agent-secrets \
+        --from-file=${STAGE2_ETC_PATH}/agent.key \
+        --from-file=${STAGE2_ETC_PATH}/agent.crt \
+        --from-file=${STAGE2_ETC_PATH}/ca.crt \
+        --from-file=${STAGE2_ETC_PATH}/mqpassword \
+        --from-file=${STAGE2_ETC_PATH}/mig-agent.cfg
+    kubectl -n mig create -f ${STAGE2_ETC_PATH}/migdaemonset.yaml
 }
 
 install_dd() {
-	echo "Installing Datadog"
-	kubectl create namespace datadog | true
-	kubectl create -f ${STAGE2_ETC_PATH}/dd-agent.yaml
+    echo "Installing Datadog"
+    kubectl create namespace datadog | true
+    kubectl create -f ${STAGE2_ETC_PATH}/dd-agent.yaml
 }
 
 install_newrelic() {
-	echo "Installing New Relic"
-	kubectl create namespace newrelic | true
+    echo "Installing New Relic"
+    kubectl create namespace newrelic | true
 
-	kubectl create -f ${STAGE2_ETC_PATH}/newrelic-config.yaml
-	# replace "mycluster" with the SHORT_NAME specified in stage1.sh
-	cat ${STAGE2_ETC_PATH}/newrelic-daemonset.yaml.template | sed "s/mycluster/${KOPS_SHORT_NAME}/" | kubectl create -f -
+    kubectl create -f ${STAGE2_ETC_PATH}/newrelic-config.yaml
+    # replace "mycluster" with the SHORT_NAME specified in stage1.sh
+    cat ${STAGE2_ETC_PATH}/newrelic-daemonset.yaml.template | sed "s/mycluster/${KOPS_SHORT_NAME}/" | kubectl create -f -
 }
 
 install_k8s_dashboard() {
-	echo "Installing k8s dashboard"
-	kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
+    echo "Installing k8s dashboard"
+    kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
 }
 
 install_heapster() {
-	echo "Installing heapster"
-	kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
+    echo "Installing heapster"
+    kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
 }
 
 install_fluentd() {
-	echo "Installing fluentd"
+    echo "Installing fluentd"
     helm install ${KOPS_INSTALLER}/charts/mozmeao --set fluentd.syslog_host=${SYSLOG_HOST},fluentd.syslog_port=${SYSLOG_PORT}
 }
 
 
 install_tiller() {
-	echo "Installing tiller"
-	helm init
-	echo "Waiting for tiller to start"
-	# TODO: hackey version of waiting for a pod to start, REPLACE THIS
-	until kubectl -n kube-system get pods | grep tiller | grep Running | grep "1/1"
-	do
-		sleep 1
-	done
-	echo "Tiller installed!"
+    echo "Installing tiller"
+    helm init
+    echo "Waiting for tiller to start"
+    # TODO: hackey version of waiting for a pod to start, REPLACE THIS
+    until kubectl -n kube-system get pods | grep tiller | grep Running | grep "1/1"
+    do
+        sleep 1
+    done
+    echo "Tiller installed!"
 }
 
+# use this if you need to reinstall Deis and secrets already exist
+delete_deis_secrets() {
+    kubectl -n deis get secrets | tail -n +2 | awk '{ print $1 }' | xargs kubectl -n deis delete secret
+}
 
+install_workflow_chart() {
+    # make sure we're running from a directory with config.sh
+    check_cwd
+    echo "Installing Deis Workflow"
+    helm repo add deis https://charts.deis.com/workflow
+    helm inspect values deis/workflow | sed -n '1!p' > workflow_config.yaml
+    TF_OUTPUT_CMD="terraform output --state ./out/terraform/.terraform/terraform.tfstate"
 
-install_workflow() {
-	echo "Installing Deis Workflow"
-	helm repo add deis https://charts.deis.com/workflow
-	helm inspect values deis/workflow | sed -n '1!p' > workflow_config.yaml
+    # s3 settings
+    region=$(${TF_OUTPUT_CMD} region)
+    registry_bucket=$(${TF_OUTPUT_CMD} registry-bucket)
+    builder_bucket=$(${TF_OUTPUT_CMD} builder-bucket)
+    s3_accesskey=$(${TF_OUTPUT_CMD} deis_s3_accesskey)
+    s3_secretkey=$(${TF_OUTPUT_CMD} deis_s3_secretkey)
 
-	# s3 settings
-	region=$(terraform output -json | jq -r .region.value)
-	registry_bucket=$(terraform output -json | jq -r '."registry-bucket"'.value)
-	builder_bucket=$(terraform output -json | jq -r '."builder-bucket"'.value)
-	s3_accesskey=$(terraform output -json | jq -r '."deis_s3_accesskey"'.value)
-	s3_secretkey=$(terraform output -json | jq -r '."deis_s3_secretkey"'.value)
-
-	# rds settings
-	if [ -z "${KOPS_EXISTING_RDS}" ]
-	then
-		echo "Using new RDS instance"
-		pgsql_address=$(terraform output -json | jq -r '."pgsql_address"'.value)
-		pgsql_db_name=$(terraform output -json | jq -r '."pgsql_db_name"'.value)
-		pgsql_password=$(terraform output -json | jq -r '."pgsql_password"'.value)
-		pgsql_port=$(terraform output -json | jq -r '."pgsql_port"'.value)
-		pgsql_username=$(terraform output -json | jq -r '."pgsql_username"'.value)
-	else
-		echo "Using existing RDS settings"
-		pgsql_address=${KOPS_PGSQL_ADDRESS}
-		pgsql_db_name=${KOPS_PGSQL_DB_NAME}
-		pgsql_password=${KOPS_PGSQL_PASSWORD}
-		pgsql_port=${KOPS_PGSQL_PORT}
-		pgsql_username=${KOPS_PGSQL_USERNAME}
-	fi
+    # rds settings
+    if [ -z "${KOPS_EXISTING_RDS}" ]
+    then
+        echo "Using new RDS instance"
+        pgsql_address=$(${TF_OUTPUT_CMD} pgsql_address)
+        pgsql_db_name=$(${TF_OUTPUT_CMD} pgsql_db_name)
+        pgsql_password=$(${TF_OUTPUT_CMD} pgsql_password)
+        pgsql_port=$(${TF_OUTPUT_CMD} pgsql_port)
+        pgsql_username=$(${TF_OUTPUT_CMD} pgsql_username)
+    else
+        echo "Using existing RDS settings"
+        pgsql_address=${KOPS_PGSQL_ADDRESS}
+        pgsql_db_name=${KOPS_PGSQL_DB_NAME}
+        pgsql_password=${KOPS_PGSQL_PASSWORD}
+        pgsql_port=${KOPS_PGSQL_PORT}
+        pgsql_username=${KOPS_PGSQL_USERNAME}
+    fi
 
     # this block of code sets up:
     # - global s3 storage + aws creds
     # - RDS postgres host/port/username/password
     # - Deis registration disabled
-	y2j < workflow_config.yaml \
-		| jq ".global.storage = \"s3\"" \
-		| jq ".s3.region = \"${region}\"" \
-		| jq ".s3.registry_bucket = \"${registry_bucket}\"" \
-		| jq ".s3.builder_bucket = \"${builder_bucket}\"" \
-		| jq ".s3.database_bucket = \"\"" \
-		| jq ".s3.accesskey = \"${s3_accesskey}\"" \
-		| jq ".s3.secretkey = \"${s3_secretkey}\"" \
-		| jq ".global.database_location = \"off-cluster\"" \
-		| jq ".database.password = \"${pgsql_password}\"" \
-		| jq ".database.postgres.host = \"${pgsql_address}\"" \
-		| jq ".database.postgres.name = \"${pgsql_db_name}\"" \
-		| jq ".database.postgres.password = \"${pgsql_password}\"" \
-		| jq ".database.postgres.port = \"${pgsql_port}\"" \
-		| jq ".database.postgres.username = \"${pgsql_username}\"" \
-		| jq ".controller.registration_mode = \"disabled\"" \
-		| jq ".registry_location = \"off-cluster\"" \
-		| jq ".\"registry-token-refresher\".off_cluster_registry.hostname = \"${REGISTRY_HOSTNAME}\"" \
-		| jq ".\"registry-token-refresher\".off_cluster_registry.organization = \"${REGISTRY_ORG}\"" \
-		| jq ".\"registry-token-refresher\".off_cluster_registry.username = \"${REGISTRY_USERNAME}\"" \
-		| jq ".\"registry-token-refresher\".off_cluster_registry.password = \"${REGISTRY_PASSWORD}\"" \
-		| j2y > workflow_config_moz.yaml
+    y2j < workflow_config.yaml \
+        | jq ".global.storage = \"s3\"" \
+        | jq ".s3.region = \"${region}\"" \
+        | jq ".s3.registry_bucket = \"${registry_bucket}\"" \
+        | jq ".s3.builder_bucket = \"${builder_bucket}\"" \
+        | jq ".s3.database_bucket = \"\"" \
+        | jq ".s3.accesskey = \"${s3_accesskey}\"" \
+        | jq ".s3.secretkey = \"${s3_secretkey}\"" \
+        | jq ".global.database_location = \"off-cluster\"" \
+        | jq ".database.password = \"${pgsql_password}\"" \
+        | jq ".database.postgres.host = \"${pgsql_address}\"" \
+        | jq ".database.postgres.name = \"${pgsql_db_name}\"" \
+        | jq ".database.postgres.password = \"${pgsql_password}\"" \
+        | jq ".database.postgres.port = \"${pgsql_port}\"" \
+        | jq ".database.postgres.username = \"${pgsql_username}\"" \
+        | jq ".controller.registration_mode = \"disabled\"" \
+        | jq ".registry_location = \"off-cluster\"" \
+        | jq ".\"registry-token-refresher\".off_cluster_registry.hostname = \"${REGISTRY_HOSTNAME}\"" \
+        | jq ".\"registry-token-refresher\".off_cluster_registry.organization = \"${REGISTRY_ORG}\"" \
+        | jq ".\"registry-token-refresher\".off_cluster_registry.username = \"${REGISTRY_USERNAME}\"" \
+        | jq ".\"registry-token-refresher\".off_cluster_registry.password = \"${REGISTRY_PASSWORD}\"" \
+        | j2y > workflow_config_moz.yaml
 
     # if you are reinstalling Deis after a `helm delete ...`, you'll need to delete
     # the secrets as well:
@@ -188,7 +202,7 @@ install_workflow() {
     sed -i "s/6443/8080/" workflow/charts/router/templates/router-service.yaml
 
     # if installing an unmodified deis/workflow:
-	# helm install deis/workflow --namespace deis -f workflow_config_moz.yaml
+    # helm install deis/workflow --namespace deis -f workflow_config_moz.yaml
     # otherwise, we're using our tweaked version on the local filesystem:
     helm install ./workflow --namespace deis -f workflow_config_moz.yaml
 }
@@ -217,11 +231,22 @@ config_deis_dns() {
     echo "Done"
 }
 
-config_elb_ssl() {
+config_annotations() {
     # https://deis.com/docs/workflow/managing-workflow/configuring-load-balancers/
     # Configure proxy protocol
-    kubectl --namespace=deis annotate deployment/deis-router router.deis.io/nginx.useProxyProtocol=true
-    kubectl --namespace=deis annotate service/deis-router service.beta.kubernetes.io/aws-load-balancer-proxy-protocol='*'
+    kubectl --namespace=deis annotate service/deis-router \
+        service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout=1200
+
+    kubectl --namespace=deis annotate deployment/deis-router \
+        router.deis.io/nginx.useProxyProtocol=true
+
+    kubectl --namespace=deis annotate service/deis-router \
+        service.beta.kubernetes.io/aws-load-balancer-proxy-protocol='*'
+
+    # this creates a DNS entry for deis.foo.moz.works and points it at the ELB for us
+    kubectl --namespace=deis annotate service/deis-router \
+        dns.alpha.kubernetes.io/external="deis.${KOPS_NAME}"
+
     AWS_ACCOUNT_ID=$(aws ec2 describe-security-groups --group-names 'Default' --region ${KOPS_REGION} | jq -r .SecurityGroups[0].OwnerId)
 
     # https config for k8s
@@ -235,25 +260,9 @@ config_elb_ssl() {
     kubectl --namespace=deis annotate service/deis-router ${ANNOTATION2}
 }
 
-config_deis_elb_timeout() {
-    echo "Waiting for Deis router LB"
-    # the -e flag to jq will cause it to return a 1 if the path isn't found in the json
-    until kubectl --namespace=deis get svc deis-router -o json | jq -e -r .status.loadBalancer.ingress[0].hostname
-    do
-      sleep 1
-    done
-    echo "Deis router LB available"
-
-    ELB=$(kubectl --namespace=deis get svc deis-router -o json | jq -r .status.loadBalancer.ingress[0].hostname)
-    echo "ELB = ${ELB}"
-    BASE_ELB_NAME=$(echo $ELB | tr "-" " " | awk '{ print $1 }')
-    echo "BASE ELB = ${BASE_ELB_NAME}"
-
-    echo "Setting ELB IdleTimeout to 1200 seconds"
-    aws elb modify-load-balancer-attributes \
-            --load-balancer-name ${BASE_ELB_NAME} \
-            --load-balancer-attributes "{\"ConnectionSettings\":{\"IdleTimeout\":1200}}" \
-            --region ${KOPS_REGION}
-
-    echo "Done"
+install_deis() {
+    check_cwd
+    install_workflow_chart
+    config_annotations
+    config_deis_dns
 }


### PR DESCRIPTION
- instead of running stage2 from `./out/terraform`, run it from the same dir as stage1
- add a k8s annotation that creates a deis.foo.moz.works CNAME pointing to the ELB
- added a function called `install_deis` that runs all the workflow install steps
- rename `install_workflow` to `install_workflow_chart`
  - instead of parsing Terraform output with `jq`, just supply the param name to tf and it does the same thing
Ex:
`terraform output foo` gives me the value of foo, instead of having to filter json through `jq`.
- convert tabs to spaces
  - my bad, next text editor default is lame.

Tip: append `?w=1` to the URL to see the PR without whitespace changes.
  ex: https://github.com/mozmar/infra/pull/18/files?w=1