### PR TITLE
add MDN provisioning scripts

### DIFF
--- a/mdn/README.md
+++ b/mdn/README.md
@@ -1,0 +1,17 @@
+# MDN infra provisioning
+
+The scripts in this directory are for provisioning MDN clusters.
+
+### Prerequisites:
+
+- `terraform`
+- `jq`
+- `awscli` w/ creds via the AWS metadata service OR `~/.aws/credentials configured`
+	- we prefer to use the AWS metadata service so credentials aren't left on disk.
+
+
+### Usage
+
+```
+./provision.sh
+```

--- a/mdn/mdn_infra.tf
+++ b/mdn/mdn_infra.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = "${var.region}"
 }
 
+
+
 resource "aws_elasticache_cluster" "mdn-redis" {
     cluster_id = "mdn-redis"
     engine = "redis"
@@ -38,9 +40,7 @@ resource "aws_elasticsearch_domain" "mdn-elasticsearch" {
             "Action": "es:*",
             "Principal": "*",
             "Effect": "Allow",
-            "Condition": {
-                "IpAddress": {"aws:SourceIp": "$${var.es-source-ip}"}
-            }
+             "Resource": ["arn:aws:ec2:${var.region}:*:mdn-elasticsearch-access/*"]
         }
     ]
 }
@@ -50,5 +50,25 @@ CONFIG
   }
   tags {
     Domain = "mdn-elasticsearch"
+  }
+}
+
+
+resource "aws_security_group" "mdn-elasticsearch-access" {
+  name = "mdn-elasticsearch-access"
+  description = "SG for ElasticSearch"
+
+  ingress {
+      from_port = 0
+      to_port = 9200
+      protocol = "tcp"
+      security_groups = "${var.es_security_groups}"
+  }
+
+  ingress {
+      from_port = 0
+      to_port = 9300
+      protocol = "tcp"
+      security_groups = "${var.es_security_groups}"
   }
 }

--- a/mdn/mdn_infra.tf
+++ b/mdn/mdn_infra.tf
@@ -1,0 +1,54 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+resource "aws_elasticache_cluster" "mdn-redis" {
+    cluster_id = "mdn-redis"
+    engine = "redis"
+    node_type = "${var.cache-node-size}"
+    port = "${var.cache-port}"
+    num_cache_nodes = "${var.cache-num-nodes}"
+    parameter_group_name = "${var.cache-param-group}"
+}
+
+resource "aws_elasticsearch_domain" "mdn-elasticsearch" {
+  domain_name           = "mdn-elasticsearch"
+  elasticsearch_version = "${var.es-version}"
+
+  cluster_config {
+    instance_type  = "${var.es-instance-type}"
+    instance_count = "${var.es-instance-count}"
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "${var.es-ebs-volume-type}"
+    volume_size = "${var.es-ebs-volume-size}"
+  }
+
+  #advanced_options {
+  #    "rest.action.multi.allow_explicit_index" = true
+  #}
+
+  access_policies = <<CONFIG
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Principal": "*",
+            "Effect": "Allow",
+            "Condition": {
+                "IpAddress": {"aws:SourceIp": "$${var.es-source-ip}"}
+            }
+        }
+    ]
+}
+CONFIG
+  snapshot_options {
+    automated_snapshot_start_hour = "${var.es-snapshot-hour}"
+  }
+  tags {
+    Domain = "mdn-elasticsearch"
+  }
+}

--- a/mdn/provision.sh
+++ b/mdn/provision.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+MDN_REGION="us-east-1"
+MDN_TF_STATE_BUCKET="mdn-tf-state"
+
+setup_tf_s3_state_store() {
+    echo "Creating Terraform state bucket at s3://${MDN_TF_STATE_BUCKET} (region ${MDN_REGION})"
+    # The following environment variables are defined in config.sh
+    aws s3 mb s3://${MDN_TF_STATE_BUCKET} --region ${MDN_REGION}
+
+    echo "Configuring Terraform to use an encrypted remote S3 bucket for state storage"
+    # store TF state in S3
+    terraform remote config \
+        -backend=s3 \
+        -backend-config="bucket=${MDN_TF_STATE_BUCKET}" \
+        -backend-config="key=mdn-${MDN_REGION}/terraform.tfstate" \
+        -backend-config="encrypt=1" \
+        -backend-config="region=${MDN_REGION}"
+
+    echo "Encryption for TF state:"
+    aws s3api head-object --bucket=$MDN_TF_STATE_BUCKET --key="mdn-${MDN_REGION}/terraform.tfstate" | jq -r .ServerSideEncryption
+}
+
+setup_tf_s3_state_store
+terraform plan
+# if terraform plan fails, the next command won't run due to
+# set -e at the top of the script.
+terraform apply

--- a/mdn/variables.tf
+++ b/mdn/variables.tf
@@ -1,0 +1,51 @@
+variable "region" {
+  default = "us-east-1"
+}
+
+##### Redis
+variable "cache-node-size" {
+  default = "cache.t2.micro"
+}
+
+variable "cache-port" {
+  default = "6379"
+}
+
+variable "cache-num-nodes" {
+  default = "1"
+}
+
+variable "cache-param-group" {
+  default = "default.redis3.2"
+}
+
+##### Elasticsearch
+variable "es-version" {
+  default = "5.1"
+}
+
+variable "es-source-ip" {
+  default = ["192.168.1.2/32"]
+}
+
+# 24-hour format, not sure which tz it's based on
+variable "es-snapshot-hour" {
+  default = 23
+}
+
+variable "es-instance-type" {
+  default = "m3.medium.elasticsearch"
+}
+
+variable "es-instance-count" {
+  default = 3
+}
+
+variable "es-ebs-volume-type" {
+  default = "gp2"
+}
+
+# specified in GiBs
+variable "es-ebs-volume-size" {
+  default = "10"
+}

--- a/mdn/variables.tf
+++ b/mdn/variables.tf
@@ -24,8 +24,11 @@ variable "es-version" {
   default = "5.1"
 }
 
-variable "es-source-ip" {
-  default = ["192.168.1.2/32"]
+# The ElasticSearch security group grants port access to any
+# security group listed in this variable
+variable "es_security_groups" {
+  type = "list"
+  default = []
 }
 
 # 24-hour format, not sure which tz it's based on


### PR DESCRIPTION
This used to be https://github.com/mozmar/ee-infra-private/pull/63, however we'd like to keep as much of this in the public as possible.

Additions:
- README
- a `provision.sh` script that sets up an encrypted S3 bucket for Terraform remote state

fyi @jwhitlock 