### PR TITLE
add MDN provisioning scripts

### DIFF
--- a/mdn/README.md
+++ b/mdn/README.md
@@ -1,0 +1,29 @@
+# MDN infra
+
+### Requirements:
+
+- Terraform
+- Access to the IAM role `admin` role via the AWS metadata API
+- awscli
+
+
+## Usage
+
+```
+./provision.sh
+```
+
+This will setup the S3 Terraform state store if needed, and then run `terraform plan` followed by `terraform apply`.
+
+---
+
+NOTE:
+
+As the `mdn-downloads` bucket already exists and was created outside of Terraform, it was imported with the following command:
+
+
+```
+terraform import aws_s3_bucket.mdn-downloads mdn-downloads
+```
+
+This resource is stored in the Terraform S3 state, so the command doesn't need to be run again.

--- a/mdn/mdn_infra.tf
+++ b/mdn/mdn_infra.tf
@@ -38,12 +38,6 @@ resource "aws_s3_bucket" "mdn-downloads" {
 
     website_domain="s3-website-${var.region}.amazonaws.com"
     website_endpoint="mdn-downloads.s3-website-${var.region}.amazonaws.com"
-
-}
-
-resource "aws_iam_policy" "mdn-downloads-policy" {
-    name = "mdn-downloads-developer"
-    description = "IAM policy for MDN S3 downloads"
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -89,7 +83,7 @@ resource "aws_iam_policy" "mdn-downloads-policy" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::mdn-downloads/sample_db.sql.gz"
+      "Resource": "arn:aws:s3:::mdn-downloads/mdn_sample_db.sql.gz"
     },
     {
       "Sid": "MDNDownloadAllowAssetsSlashStar",
@@ -101,11 +95,6 @@ resource "aws_iam_policy" "mdn-downloads-policy" {
   ]
 }
 EOF
-}
-
-resource "aws_s3_bucket_policy" "mdn-downloads" {
-  bucket = "${aws_s3_bucket.mdn-downloads.id}"
-  policy = "${aws_iam_policy.mdn-downloads-policy.policy}"
 }
 
 

--- a/mdn/mdn_infra.tf
+++ b/mdn/mdn_infra.tf
@@ -1,0 +1,166 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+# access is controlled via private IAM policy
+resource "aws_s3_bucket" "mdn-db-storage-anonymized" {
+    bucket = "mdn-db-storage-anonymized"
+    region = "${var.region}"
+}
+
+# access is controlled via private IAM policy
+resource "aws_s3_bucket" "mdn-db-storage-production" {
+    bucket = "mdn-db-storage-production"
+    region = "${var.region}"
+}
+
+resource "aws_s3_bucket" "mdn-downloads" {
+    bucket = "mdn-downloads"
+    region = "${var.region}"
+    acl = ""
+    force_destroy = ""
+    cors_rule {
+        allowed_headers = ["*"]
+        allowed_methods = ["GET"]
+        allowed_origins = ["*"]
+        max_age_seconds = 3000
+    }
+    hosted_zone_id="${lookup(var.hosted-zone-id-defs, var.region)}"
+
+    logging {
+       target_bucket = "mdn-downloads"
+       target_prefix = "logs/"
+    }
+
+    website {
+      index_document = "index.html"
+    }
+
+    website_domain="s3-website-${var.region}.amazonaws.com"
+    website_endpoint="mdn-downloads.s3-website-${var.region}.amazonaws.com"
+
+}
+
+resource "aws_iam_policy" "mdn-downloads-policy" {
+    name = "mdn-downloads-developer"
+    description = "IAM policy for MDN S3 downloads"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Id": "mdn-downloads policy",
+  "Statement": [
+    {
+      "Sid": "MDNDownloadAllowListBucket",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::mdn-downloads"
+    },
+    {
+      "Sid": "MDNDownloadAllowSampledbStar",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mdn-downloads/sampledb/*"
+    },
+    {
+      "Sid": "MDNDownloadAllowIndexDotHTML",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mdn-downloads/index.html"
+    },
+    {
+      "Sid": "MDNDownloadAllowListDotHTML",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mdn-downloads/list.html"
+    },
+    {
+      "Sid": "MDNDownloadAllowTarball",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mdn-downloads/developer.mozilla.org.tar.gz"
+    },
+    {
+      "Sid": "MDNDownloadAllowSampleDB",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mdn-downloads/sample_db.sql.gz"
+    },
+    {
+      "Sid": "MDNDownloadAllowAssetsSlashStar",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::mdn-downloads/assets/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket_policy" "mdn-downloads" {
+  bucket = "${aws_s3_bucket.mdn-downloads.id}"
+  policy = "${aws_iam_policy.mdn-downloads-policy.policy}"
+}
+
+
+/*
+Uncomment these when we're ready!
+You'll also need the variables in variables.tf
+
+resource "aws_elasticache_cluster" "mdn-redis" {
+    cluster_id = "mdn-redis"
+    engine = "redis"
+    node_type = "${var.cache-node-size}"
+    port = "${var.cache-port}"
+    num_cache_nodes = "${var.cache-num-nodes}"
+    parameter_group_name = "${var.cache-param-group}"
+}
+
+resource "aws_elasticsearch_domain" "mdn-elasticsearch" {
+  domain_name           = "mdn-elasticsearch"
+  elasticsearch_version = "${var.es-version}"
+
+  cluster_config {
+    instance_type  = "${var.es-instance-type}"
+    instance_count = "${var.es-instance-count}"
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "${var.es-ebs-volume-type}"
+    volume_size = "${var.es-ebs-volume-size}"
+  }
+
+  #advanced_options {
+  #    "rest.action.multi.allow_explicit_index" = true
+  #}
+
+  access_policies = <<CONFIG
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Principal": "*",
+            "Effect": "Allow",
+            "Condition": {
+                "IpAddress": {"aws:SourceIp": "$${var.es-source-ip}"}
+            }
+        }
+    ]
+}
+CONFIG
+  snapshot_options {
+    automated_snapshot_start_hour = "${var.es-snapshot-hour}"
+  }
+  tags {
+    Domain = "mdn-elasticsearch"
+  }
+}
+*/

--- a/mdn/provision.sh
+++ b/mdn/provision.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+# NOTE: This variable MUST match the `region` variable in variables.tf
+MDN_REGION="us-west-2"
+MDN_TF_STATE_BUCKET="mdn-tf-state"
+
+setup_tf_s3_state_store() {
+    echo "Creating Terraform state bucket at s3://${MDN_TF_STATE_BUCKET} (region ${MDN_REGION})"
+    # The following environment variables are defined in config.sh
+    aws s3 mb s3://${MDN_TF_STATE_BUCKET} --region ${MDN_REGION}
+
+    echo "Configuring Terraform to use an encrypted remote S3 bucket for state storage"
+    # store TF state in S3
+    terraform remote config \
+        -backend=s3 \
+        -backend-config="bucket=${MDN_TF_STATE_BUCKET}" \
+        -backend-config="key=mdn-${MDN_REGION}/terraform.tfstate" \
+        -backend-config="encrypt=1" \
+        -backend-config="region=${MDN_REGION}"
+
+    echo "Encryption for TF state:"
+    aws s3api head-object --bucket=$MDN_TF_STATE_BUCKET --key="mdn-${MDN_REGION}/terraform.tfstate" | jq -r .ServerSideEncryption
+}
+
+echo "Checking state store"
+if aws s3 ls s3://${MDN_TF_STATE_BUCKET} > /dev/null 2>&1; then
+    echo "State store already exists"
+else
+    echo "Setting up state store"
+    setup_tf_s3_state_store
+fi
+
+echo "Importing mdn-downloads bucket if not present in state"
+terraform import aws_s3_bucket.mdn-downloads mdn-downloads > /dev/null 2>&1 || true
+
+terraform plan
+# if terraform plan fails, the next command won't run due to
+# set -e at the top of the script.
+terraform apply

--- a/mdn/variables.tf
+++ b/mdn/variables.tf
@@ -2,6 +2,7 @@ variable "region" {
   default = "us-west-2"
 }
 
+
 variable "hosted-zone-id-defs" {
   # See: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
   type = "map"

--- a/mdn/variables.tf
+++ b/mdn/variables.tf
@@ -1,0 +1,63 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "hosted-zone-id-defs" {
+  # See: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
+  type = "map"
+  default = {
+    us-east-1 = "Z3AQBSTGFYJSTF"
+    us-west-2 = "Z3BJ6K6RIION7M"
+  }
+}
+
+
+/*
+##### Redis
+variable "cache-node-size" {
+  default = "cache.t2.micro"
+}
+
+variable "cache-port" {
+  default = "6379"
+}
+
+variable "cache-num-nodes" {
+  default = "1"
+}
+
+variable "cache-param-group" {
+  default = "default.redis3.2"
+}
+
+##### Elasticsearch
+variable "es-version" {
+  default = "5.1"
+}
+
+variable "es-source-ip" {
+  default = ["192.168.1.2/32"]
+}
+
+# 24-hour format, not sure which tz it's based on
+variable "es-snapshot-hour" {
+  default = 23
+}
+
+variable "es-instance-type" {
+  default = "m3.medium.elasticsearch"
+}
+
+variable "es-instance-count" {
+  default = 3
+}
+
+variable "es-ebs-volume-type" {
+  default = "gp2"
+}
+
+# specified in GiBs
+variable "es-ebs-volume-size" {
+  default = "10"
+}
+*/


### PR DESCRIPTION
This PR builds on https://github.com/mozmar/infra/pull/59, however, I commented out the Redis and Elasticsearch resources until needed.

**These resources have NOT been allocated via Terraform yet.**

The following buckets are created:

- `mdn-db-storage-anonymized`
- `mdn-db-storage-production`

`mdn-downloads` already exists, but with this PR, it's now managed via Terraform.

### Notes:
- user accounts and IAM policies created in https://github.com/mozmar/ee-infra-private/pull/69
- ~we may need to rename `mdn-db-storage-anonymized` and `mdn-db-storage-production`, as AWS was timing out during bucket creation.~
- ~We may need additional permissions on the IAM policy for `mdn-downloads` to allow for logging. If this is a problem, it won't show up until I run `provision.sh`.~
- ~before applying this change, I'd like to create a backup bucket with the contents of `mdn-downloads`.~ 
   - Backup at `mdn-downloads-backup`, will be deleted after this PR is merged.

cc @jgmize @jwhitlock 
