### PR TITLE
add mdn maint mode MySQL install script

### DIFF
--- a/mdn/services/README.md
+++ b/mdn/services/README.md
@@ -28,9 +28,10 @@ apt-get update && apt-get install mysql-client -y
 # you'll need the password from $PATH_TO_MYSQL_SETTINGS
 mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p
 
-# after logging into the mysql client:
-show databases;
-exit;
+# to import the mm db:
+wget -N https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
+zcat mdn_sample_db.sql.gz | mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p mdn-mm 
+
 
 # we can't start another pod named "ubuntu" unless this one is deleted.
 # you can see completed pods w/ kubectl get pods --show-all

--- a/mdn/services/README.md
+++ b/mdn/services/README.md
@@ -1,0 +1,38 @@
+# MySQL for MDN Maintenance Mode
+
+The `install_mysql.sh` script in this directory deploys a MySQL instance via [helm chart](https://github.com/kubernetes/charts/tree/master/stable/mysql). 
+
+Since we use [a custom MySQL image](https://quay.io/repository/mozmar/mdn-mysql?tag=latest&tab=tags) with custom collation, we need to modify the MySQL Chart on the fly to use our image instead of the default.
+
+### Prereqs
+
+- Access to the private infra repo
+- `kubectl`, pointing at the appropriate K8s cluster
+- `helm`
+
+### Usage
+
+```
+./install_mysql.sh
+```
+
+### Connecting to MySQL
+
+You can start a temporary container to connect to the new MySQL instance:
+
+```
+kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
+
+apt-get update && apt-get install mysql-client -y
+
+# you'll need the password from $PATH_TO_MYSQL_SETTINGS
+mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p
+
+# after logging into the mysql client:
+show databases;
+exit;
+
+# we can't start another pod named "ubuntu" unless this one is deleted.
+# you can see completed pods w/ kubectl get pods --show-all
+kubectl delete pod ubuntu
+```

--- a/mdn/services/README.md
+++ b/mdn/services/README.md
@@ -23,7 +23,7 @@ You can start a temporary container to connect to the new MySQL instance:
 ```
 kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
 
-apt-get update && apt-get install mysql-client -y
+apt-get update && apt-get install mysql-client wget -y
 
 # you'll need the password from $PATH_TO_MYSQL_SETTINGS
 mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p

--- a/mdn/services/README.md
+++ b/mdn/services/README.md
@@ -32,6 +32,9 @@ mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p
 wget -N https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
 zcat mdn_sample_db.sql.gz | mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p mdn-mm 
 
+# to create a user for development:
+CREATE USER 'kuma_ro'@'%' IDENTIFIED BY 'kuma';
+GRANT SELECT ON `mdn-mm`.* TO kuma_ro@`%`;
 
 # we can't start another pod named "ubuntu" unless this one is deleted.
 # you can see completed pods w/ kubectl get pods --show-all

--- a/mdn/services/install_mysql.sh
+++ b/mdn/services/install_mysql.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+export KUBECONFIG="/home/admin/ee-infra-private/k8s/clusters/virginia/virginia.kubeconfig"
+
+# if the private repo is still locked, this will fail
+if ! kubectl config current-context; then
+    echo "Can't access k8s, is the repo still locked?"
+    exit 1
+fi
+
+PATH_TO_MYSQL_SETTINGS="/home/admin/ee-infra-private/mdn/services/mysql/mdn-mm-mysql-values.yaml"
+MM_NAMESPACE="mdn-mm"
+CHART_INSTANCE_NAME="mdn-mm-mysql"
+
+echo "Creating k8s namespace ${MM_NAMESPACE}"
+kubectl create namespace "${MM_NAMESPACE}" || true
+
+echo "Fetching mysql chart"
+helm fetch stable/mysql --untar
+
+echo "Patching chart to support mozmar/mdn-mysql"
+sed -i "s#mysql:{{#quay.io/mozmar/mdn-mysql:{{#" mysql/templates/deployment.yaml
+
+echo "Installing chart"
+helm install \
+    --name "${CHART_INSTANCE_NAME}" \
+     ./mysql \
+     --namespace "${MM_NAMESPACE}" \
+     -f "${PATH_TO_MYSQL_SETTINGS}"


### PR DESCRIPTION
Requires: https://github.com/mozmar/ee-infra-private/pull/70

Test with:

```
kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
apt-get update && apt-get install mysql-client wget -y
# you'll need the password from $PATH_TO_MYSQL_SETTINGS
mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p

# after logging into the mysql client:
show databases;
exit;

# to import the mm db:
wget -N https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
zcat mdn_sample_db.sql.gz | mysql -h mdn-mm-mysql-mysql.mdn-mm.svc.cluster.local -p mdn-mm 

# we can't start another pod named "ubuntu" unless this one is deleted.
# you can see completed pods w/ kubectl get pods --show-all
kubectl delete pod ubuntu
```