### PR TITLE
Allow single AZ k8s installations

### DIFF
--- a/k8s/install/README.md
+++ b/k8s/install/README.md
@@ -133,6 +133,14 @@ kops rolling-update cluster ${KOPS_NAME} --force --yes
 
 It's easiest to run this before the cluster has any pods/services installed and running.
 
+### Disable public SSH
+
+```
+cd k8s/tools
+./k8s_ssh_security.sh --disable
+```
+
+
 ### Installing monitoring services (stage2)
 
 This step installs Mig, Datadog, New Relic DaemonSets, the k8s dashboard, and Deis Workflow.
@@ -148,6 +156,7 @@ Note: each DaemonSet is installed into it's own namespace: `mig`, `datadog`, `ne
 
 ---
 # Post install
+
 
 ### Generating kubeconfig
 

--- a/k8s/install/README.md
+++ b/k8s/install/README.md
@@ -49,7 +49,7 @@ kops edit ig nodes
 A yaml file will appear in your $EDITOR, you'll need to add the following block to the `spec` section:
 
 ```
-  rootVolumeSize: 500
+  rootVolumeSize: 250
   rootVolumeType: gp2
 ```
 

--- a/k8s/install/README.md
+++ b/k8s/install/README.md
@@ -106,6 +106,33 @@ kubectl config current-context
 kubectl get nodes
 ```
 
+
+### Enabling K8s cron
+
+- See https://github.com/kubernetes/kops/issues/618
+
+```
+kops edit cluster ${KOPS_NAME}
+```
+
+Add the following under the `spec` section:
+
+```
+  kubeAPIServer:
+    runtimeConfig:
+      "batch/v2alpha1": "true"
+```
+
+> Note: the value `true` MUST appear in double quotes.
+
+Now apply the changes to the cluster:
+
+```
+kops rolling-update cluster ${KOPS_NAME} --force --yes
+```
+
+It's easiest to run this before the cluster has any pods/services installed and running.
+
 ### Installing monitoring services (stage2)
 
 This step installs Mig, Datadog, New Relic DaemonSets, the k8s dashboard, and Deis Workflow.

--- a/k8s/install/etc/deis_rds.tf.template
+++ b/k8s/install/etc/deis_rds.tf.template
@@ -1,9 +1,7 @@
 # NOTE: The following values are replaced via sed as part of stage1.sh
 # TF_RESOURCE_NAME
 # KOPS_NAME
-# KOPS_AZ0
-# KOPS_AZ1
-# KOPS_AZ2
+# KOPS_AZS
 
 /*
 Create an RDS instance, subnets and security groups
@@ -28,9 +26,11 @@ resource "aws_db_instance" "default" {
 resource "aws_db_subnet_group" "default" {
   name        = "main_subnet_group"
   description = "Database subnets"
-  subnet_ids  = ["${aws_subnet.KOPS_AZ0-TF_RESOURCE_NAME.id}",
-                  "${aws_subnet.KOPS_AZ1-TF_RESOURCE_NAME.id}",
-                  "${aws_subnet.KOPS_AZ2-TF_RESOURCE_NAME.id}"]
+  # subnet_ids  = ["${aws_subnet.KOPS_AZ0-TF_RESOURCE_NAME.id}",
+  #                 "${aws_subnet.KOPS_AZ1-TF_RESOURCE_NAME.id}",
+  #                 "${aws_subnet.KOPS_AZ2-TF_RESOURCE_NAME.id}"]
+
+  subnet_ids  = [KOPS_AZS]
 }
 
 /********************

--- a/k8s/install/etc/deis_rds.tf.template
+++ b/k8s/install/etc/deis_rds.tf.template
@@ -26,10 +26,6 @@ resource "aws_db_instance" "default" {
 resource "aws_db_subnet_group" "default" {
   name        = "main_subnet_group"
   description = "Database subnets"
-  # subnet_ids  = ["${aws_subnet.KOPS_AZ0-TF_RESOURCE_NAME.id}",
-  #                 "${aws_subnet.KOPS_AZ1-TF_RESOURCE_NAME.id}",
-  #                 "${aws_subnet.KOPS_AZ2-TF_RESOURCE_NAME.id}"]
-
   subnet_ids  = [KOPS_AZS]
 }
 

--- a/k8s/install/stage2.sh
+++ b/k8s/install/stage2.sh
@@ -31,10 +31,7 @@ if [ "${INSTALL_NEWRELIC}" -eq 1 ]; then install_newrelic; fi
 if [ "${INSTALL_FLUENTD}" -eq 1 ]; then install_fluentd; fi
 
 if [ "${INSTALL_WORKFLOW}" -eq 1 ]; then
-    install_workflow
-    config_deis_dns
-    config_elb_ssl
-    config_deis_elb_timeout
+    install_deis
 fi
 
 


### PR DESCRIPTION
- Deis RDS still requires 2 AZ's
- there are some manual steps included to set worker node disk sizes and enable cron tasks.
- See: https://github.com/mozmar/ee-infra-private/pull/73