### PR TITLE
Snippets Tokyo infra provisioning, multi-region support included.

### DIFF
--- a/snippets/README.md
+++ b/snippets/README.md
@@ -2,14 +2,14 @@
 
 ### How to apply config to a single cluster
 
-```
+```shell
 cd ./tokyo
 ./provision.sh
 ```
 
 ### Adding a new cluster
 
-```
+```shell
 # from this directory
 mkdir my_snippets_region
 cp ./tokyo/provision.sh ./my_snippets_region/provision.sh

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -1,0 +1,22 @@
+## Snippets
+
+### How to apply config to a single cluster
+
+```
+cd ./tokyo
+./provision.sh
+```
+
+### Adding a new cluster
+
+```
+# from this directory
+mkdir my_snippets_region
+cp ./tokyo/provision.sh ./my_snippets_region/provision.sh
+# edit ./my_snippets_region/provision.sh
+chmod 755 ./my_snippets_region/provision.sh 
+git add ./my_snippets_region/provision.sh 
+git commit
+cd ./my_snippets_region
+./provision.sh
+```

--- a/snippets/common.sh
+++ b/snippets/common.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${SNIPPETS_REGION}" ]; then
+  echo "SNIPPETS_REGION must be set"
+  exit -1
+fi
+
+# NOTE: This variable MUST match the `region` variable in variables.tf
+#SNIPPETS_REGION="ap-northeast-1"
+SNIPPETS_TF_STATE_BUCKET="snippets-shared-tf-state"
+STATE_BUCKET_REGION="us-west-2"
+
+setup_tf_s3_state_store() {
+    echo "Creating Terraform state bucket at s3://${SNIPPETS_TF_STATE_BUCKET} (region ${STATE_BUCKET_REGION})"
+    # The following environment variables are defined in config.sh
+    aws s3 mb s3://${SNIPPETS_TF_STATE_BUCKET} --region ${STATE_BUCKET_REGION}
+
+    echo "Configuring Terraform to use an encrypted remote S3 bucket for state storage"
+    # store TF state in S3
+    terraform remote config \
+        -backend=s3 \
+        -backend-config="bucket=${SNIPPETS_TF_STATE_BUCKET}" \
+        -backend-config="key=snippets-${SNIPPETS_REGION}/terraform.tfstate" \
+        -backend-config="encrypt=1" \
+        -backend-config="region=${STATE_BUCKET_REGION}"
+
+    echo "Encryption for TF state:"
+    aws s3api head-object --bucket=$SNIPPETS_TF_STATE_BUCKET --key="snippets-${SNIPPETS_REGION}/terraform.tfstate" | jq -r .ServerSideEncryption
+}
+
+echo "Checking state store"
+if aws s3 ls s3://${SNIPPETS_TF_STATE_BUCKET} > /dev/null 2>&1; then
+    echo "State store already exists"
+else
+    echo "Setting up state store"
+    setup_tf_s3_state_store
+fi
+
+terraform get ./tf
+
+terraform plan ./tf
+# if terraform plan fails, the next command won't run due to
+# set -e at the top of the script.
+terraform apply ./tf
+

--- a/snippets/tf/alerting/alerting.tf
+++ b/snippets/tf/alerting/alerting.tf
@@ -1,0 +1,43 @@
+variable "fqdn" {}
+
+variable "name" {}
+
+variable "region" {}
+
+resource "aws_route53_health_check" "health_check" {
+  fqdn                    = "${var.fqdn}"
+  port                    = 443
+  type                    = "HTTPS"
+  resource_path           = "/"
+  failure_threshold       = "3"
+  request_interval        = "30"
+  cloudwatch_alarm_name   = ""
+  cloudwatch_alarm_region = ""
+
+  tags = {
+    Name = "${var.name}"
+  }
+}
+
+/*
+# TODO: alarm_actions are per region :-(
+        we'll need to create the sns action in ap-northeast-1 etc
+resource "aws_cloudwatch_metric_alarm" "alarm" {
+  alarm_name = "${var.name}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods = "1"
+  metric_name = "HealthCheckStatus"
+  namespace = "AWS/Route53"
+  period = "60"
+  statistic = "Minimum"
+  threshold = "3"
+  alarm_actions = [
+    "arn:aws:sns:us-east-1:236517346949:MozillaMarketingSlack",
+    "arn:aws:sns:us-east-1:236517346949:eeaws"
+  ]
+  dimensions {
+    HealthCheckId = "${aws_route53_health_check.health_check.id}"
+  }
+}
+*/
+

--- a/snippets/tf/cache/cache.tf
+++ b/snippets/tf/cache/cache.tf
@@ -1,0 +1,20 @@
+variable "region" {}
+
+variable "region_short" {}
+
+variable "cache_node_size" {}
+
+variable "cache_port" {}
+
+variable "cache_num_nodes" {}
+
+variable "cache_param_group" {}
+
+resource "aws_elasticache_cluster" "shared-redis" {
+  cluster_id           = "redis-shared-${var.region_short}"
+  engine               = "redis"
+  node_type            = "${var.cache_node_size}"
+  port                 = "${var.cache_port}"
+  num_cache_nodes      = "${var.cache_num_nodes}"
+  parameter_group_name = "${var.cache_param_group}"
+}

--- a/snippets/tf/cache/cache.tf
+++ b/snippets/tf/cache/cache.tf
@@ -18,7 +18,8 @@ variable "cache_security_group" {}
 
 resource "aws_elasticache_subnet_group" "shared-redis-subnet-group" {
   name       = "shared-redis-subnet-group"
-  subnet_ids = ["${split(",",var.cache_subnet_ids)}"]
+  # https://github.com/hashicorp/terraform/issues/57#issuecomment-100372002
+  subnet_ids = ["${split(",", var.cache_subnet_ids)}"]
 }
 
 resource "aws_elasticache_replication_group" "shared-redis-rg" {

--- a/snippets/tf/cache/cache.tf
+++ b/snippets/tf/cache/cache.tf
@@ -14,6 +14,8 @@ variable "cache_engine_version" {}
 
 variable "cache_subnet_ids" {}
 
+variable "cache_security_group" {}
+
 resource "aws_elasticache_subnet_group" "shared-redis-subnet-group" {
   name       = "shared-redis-subnet-group"
   subnet_ids = ["${split(",",var.cache_subnet_ids)}"]
@@ -28,4 +30,5 @@ resource "aws_elasticache_replication_group" "shared-redis-rg" {
   parameter_group_name          = "${var.cache_param_group}"
   engine_version                = "${var.cache_engine_version}"
   subnet_group_name             = "${aws_elasticache_subnet_group.shared-redis-subnet-group.name}"
+  security_group_ids            = ["${var.cache_security_group}"]
 }

--- a/snippets/tf/cache/cache.tf
+++ b/snippets/tf/cache/cache.tf
@@ -10,11 +10,14 @@ variable "cache_num_nodes" {}
 
 variable "cache_param_group" {}
 
-resource "aws_elasticache_cluster" "shared-redis" {
-  cluster_id           = "redis-shared-${var.region_short}"
-  engine               = "redis"
-  node_type            = "${var.cache_node_size}"
-  port                 = "${var.cache_port}"
-  num_cache_nodes      = "${var.cache_num_nodes}"
-  parameter_group_name = "${var.cache_param_group}"
+variable "cache_engine_version" {}
+
+resource "aws_elasticache_replication_group" "shared-redis-rg" {
+  replication_group_id          = "shared-redis"
+  replication_group_description = "Shared redis cluster"
+  node_type                     = "${var.cache_node_size}"
+  number_cache_clusters         = "${var.cache_num_nodes}"
+  port                          = "${var.cache_port}"
+  parameter_group_name          = "${var.cache_param_group}"
+  engine_version                = "${var.cache_engine_version}"
 }

--- a/snippets/tf/cache/cache.tf
+++ b/snippets/tf/cache/cache.tf
@@ -12,6 +12,13 @@ variable "cache_param_group" {}
 
 variable "cache_engine_version" {}
 
+variable "cache_subnet_ids" {}
+
+resource "aws_elasticache_subnet_group" "shared-redis-subnet-group" {
+  name       = "shared-redis-subnet-group"
+  subnet_ids = ["${split(",",var.cache_subnet_ids)}"]
+}
+
 resource "aws_elasticache_replication_group" "shared-redis-rg" {
   replication_group_id          = "shared-redis"
   replication_group_description = "Shared redis cluster"
@@ -20,4 +27,5 @@ resource "aws_elasticache_replication_group" "shared-redis-rg" {
   port                          = "${var.cache_port}"
   parameter_group_name          = "${var.cache_param_group}"
   engine_version                = "${var.cache_engine_version}"
+  subnet_group_name             = "${aws_elasticache_subnet_group.shared-redis-subnet-group.name}"
 }

--- a/snippets/tf/common.sh
+++ b/snippets/tf/common.sh
@@ -36,12 +36,14 @@ setup_tf_s3_state_store() {
 
 check_state_store() {
     echo "Checking state store"
+    set +e
     if aws s3 ls s3://${SNIPPETS_TF_STATE_BUCKET} > /dev/null 2>&1; then
         echo "State store already exists"
     else
         echo "Setting up state store"
         setup_tf_s3_state_store
     fi
+    set -e
 }
 
 get_subnets() {

--- a/snippets/tf/common.sh
+++ b/snippets/tf/common.sh
@@ -51,10 +51,20 @@ get_subnets() {
     echo "${SUBNET_LIST}"
 }
 
+get_k8s_nodes_security_group() {
+    QUERY=".SecurityGroups[] | select(.GroupName == \"nodes.${KOPS_NAME}\") | .GroupId"
+    SECURITY_GROUP=$(aws ec2 describe-security-groups --region $TF_VAR_region | jq -r "$QUERY")
+    echo "${SECURITY_GROUP}"
+}
+
 check_state_store
 
 export TF_VAR_kops_name="${KOPS_NAME}"
 export TF_VAR_cache_subnet_ids=$(get_subnets)
+export TF_VAR_cache_security_group=$(get_k8s_nodes_security_group)
+
+echo "Using the following subnets: ${TF_VAR_cache_subnet_ids}"
+echo "Using the following security group: ${TF_VAR_cache_security_group}"
 
 terraform get
 

--- a/snippets/tf/common.sh
+++ b/snippets/tf/common.sh
@@ -40,8 +40,9 @@ fi
 
 terraform get
 
-terraform plan
+PLAN=$(mktemp)
+terraform plan --out $PLAN
 # if terraform plan fails, the next command won't run due to
 # set -e at the top of the script.
-terraform apply
-
+terraform apply $PLAN
+rm $PLAN

--- a/snippets/tf/common.sh
+++ b/snippets/tf/common.sh
@@ -38,10 +38,10 @@ else
     setup_tf_s3_state_store
 fi
 
-terraform get ./tf
+terraform get
 
-terraform plan ./tf
+terraform plan
 # if terraform plan fails, the next command won't run due to
 # set -e at the top of the script.
-terraform apply ./tf
+terraform apply
 

--- a/snippets/tf/common.sh
+++ b/snippets/tf/common.sh
@@ -12,7 +12,6 @@ if [ -z "${KOPS_NAME}" ]; then
   exit 1
 fi
 
-export TF_VAR_kops_name="${KOPS_NAME}"
 
 SNIPPETS_TF_STATE_BUCKET="snippets-shared-tf-state"
 STATE_BUCKET_REGION="us-west-2"
@@ -45,7 +44,6 @@ check_state_store() {
     fi
 }
 
-
 get_subnets() {
     QUERY=".Subnets[] | select(.Tags[]?.Value==\"$KOPS_NAME\") | .SubnetId"
     SUBNETS=$(aws ec2 describe-subnets --region $TF_VAR_region | jq -r "$QUERY" 2> /dev/null | sort)
@@ -55,8 +53,8 @@ get_subnets() {
 
 check_state_store
 
+export TF_VAR_kops_name="${KOPS_NAME}"
 export TF_VAR_cache_subnet_ids=$(get_subnets)
-echo "[[[$TF_VAR_cache_subnet_ids]]]"
 
 terraform get
 

--- a/snippets/tf/snippets.tf
+++ b/snippets/tf/snippets.tf
@@ -43,4 +43,5 @@ module "redis" {
   cache_param_group    = "${var.cache_param_group}"
   cache_engine_version = "${var.cache_engine_version}"
   cache_subnet_ids     = "${var.cache_subnet_ids}"
+  cache_security_group = "${var.cache_security_group}"
 }

--- a/snippets/tf/snippets.tf
+++ b/snippets/tf/snippets.tf
@@ -1,0 +1,44 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+##### Buckets
+
+module "bucket-stage" {
+  source       = "../tf/storage"
+  environment  = "stage"
+  region       = "${var.region}"
+  region_short = "${var.region_short}"
+}
+
+module "bucket-prod" {
+  source       = "../tf/storage"
+  environment  = "prod"
+  region       = "${var.region}"
+  region_short = "${var.region_short}"
+}
+
+module "prod-alerts" {
+  source = "../tf/alerting"
+  region = "${var.region}"
+  fqdn   = "${var.fqdn_prod}"
+  name   = "${var.alarm_name_prod}"
+}
+
+# do we want stage alerts?
+#module "stage-alerts" {
+#    source = "../tf/alerting"
+#    region = "${var.region}"
+#    fqdn = "${var.fqdn_stage}"
+#    name = "${var.alarm_name_stage}"
+#}
+
+module "redis" {
+  source            = "../tf/cache"
+  region            = "${var.region}"
+  region_short      = "${var.region_short}"
+  cache_node_size   = "${var.cache_node_size}"
+  cache_port        = "${var.cache_port}"
+  cache_num_nodes   = "${var.cache_num_nodes}"
+  cache_param_group = "${var.cache_param_group}"
+}

--- a/snippets/tf/snippets.tf
+++ b/snippets/tf/snippets.tf
@@ -42,4 +42,5 @@ module "redis" {
   cache_num_nodes      = "${var.cache_num_nodes}"
   cache_param_group    = "${var.cache_param_group}"
   cache_engine_version = "${var.cache_engine_version}"
+  cache_subnet_ids     = "${var.cache_subnet_ids}"
 }

--- a/snippets/tf/snippets.tf
+++ b/snippets/tf/snippets.tf
@@ -34,11 +34,12 @@ module "stage-alerts" {
 }
 
 module "redis" {
-  source            = "../tf/cache"
-  region            = "${var.region}"
-  region_short      = "${var.region_short}"
-  cache_node_size   = "${var.cache_node_size}"
-  cache_port        = "${var.cache_port}"
-  cache_num_nodes   = "${var.cache_num_nodes}"
-  cache_param_group = "${var.cache_param_group}"
+  source               = "../tf/cache"
+  region               = "${var.region}"
+  region_short         = "${var.region_short}"
+  cache_node_size      = "${var.cache_node_size}"
+  cache_port           = "${var.cache_port}"
+  cache_num_nodes      = "${var.cache_num_nodes}"
+  cache_param_group    = "${var.cache_param_group}"
+  cache_engine_version = "${var.cache_engine_version}"
 }

--- a/snippets/tf/snippets.tf
+++ b/snippets/tf/snippets.tf
@@ -26,12 +26,12 @@ module "prod-alerts" {
 }
 
 # do we want stage alerts?
-#module "stage-alerts" {
-#    source = "../tf/alerting"
-#    region = "${var.region}"
-#    fqdn = "${var.fqdn_stage}"
-#    name = "${var.alarm_name_stage}"
-#}
+module "stage-alerts" {
+  source = "../tf/alerting"
+  region = "${var.region}"
+  fqdn   = "${var.fqdn_stage}"
+  name   = "${var.alarm_name_stage}"
+}
 
 module "redis" {
   source            = "../tf/cache"

--- a/snippets/tf/storage/storage.tf
+++ b/snippets/tf/storage/storage.tf
@@ -1,0 +1,63 @@
+variable "region" {}
+
+variable "environment" {}
+
+variable "region_short" {}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "snippets-${var.environment}-${var.region_short}-logs"
+  region = "${var.region}"
+  acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket" "bundles" {
+  depends_on = ["aws_s3_bucket.logs"]
+  bucket     = "snippets-${var.environment}-${var.region_short}"
+  region     = "${var.region}"
+  acl        = "public-read"
+
+  policy = <<EOF
+{
+  "Id": "bucket_policy_site",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "bucket_policy_site_main",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::snippets-${var.environment}-${var.region_short}/*",
+      "Principal": "*"
+    }
+  ]
+}
+EOF
+
+  lifecycle_rule {
+    id      = "bundles"
+    prefix  = "${var.region_short}/bundles"
+    enabled = true
+
+    expiration {
+      days = 60
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "snippets-${var.environment}-${var.region_short}-logs"
+    target_prefix = "log/"
+  }
+
+  cors_rule {
+    allowed_headers = ["GET", "OPTIONS", "HEAD"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    expose_headers  = []
+    max_age_seconds = 900
+  }
+}

--- a/snippets/tf/variables.tf
+++ b/snippets/tf/variables.tf
@@ -22,3 +22,5 @@ variable "cache_param_group" {}
 variable "cache_engine_version" {}
 
 variable "cache_subnet_ids" {}
+
+variable "cache_security_group" {}

--- a/snippets/tf/variables.tf
+++ b/snippets/tf/variables.tf
@@ -18,3 +18,5 @@ variable "cache_port" {}
 variable "cache_num_nodes" {}
 
 variable "cache_param_group" {}
+
+variable "cache_engine_version" {}

--- a/snippets/tf/variables.tf
+++ b/snippets/tf/variables.tf
@@ -20,3 +20,5 @@ variable "cache_num_nodes" {}
 variable "cache_param_group" {}
 
 variable "cache_engine_version" {}
+
+variable "cache_subnet_ids" {}

--- a/snippets/tf/variables.tf
+++ b/snippets/tf/variables.tf
@@ -1,0 +1,20 @@
+variable "region" {}
+
+variable "region_short" {}
+
+variable "fqdn_prod" {}
+
+variable "fqdn_stage" {}
+
+variable "alarm_name_prod" {}
+
+variable "alarm_name_stage" {}
+
+##### Redis config
+variable "cache_node_size" {}
+
+variable "cache_port" {}
+
+variable "cache_num_nodes" {}
+
+variable "cache_param_group" {}

--- a/snippets/tokyo/provision.sh
+++ b/snippets/tokyo/provision.sh
@@ -14,5 +14,5 @@ export TF_VAR_cache_port=6379
 export TF_VAR_cache_num_nodes=1
 export TF_VAR_cache_param_group="default.redis3.2"
 
-cd .. && ./common.sh
+cd ../tf && ./common.sh
 

--- a/snippets/tokyo/provision.sh
+++ b/snippets/tokyo/provision.sh
@@ -11,7 +11,7 @@ export TF_VAR_alarm_name_stage="Snippets Stage Tokyo"
 ##### Redis config
 export TF_VAR_cache_node_size="cache.m4.xlarge"
 export TF_VAR_cache_port=6379
-export TF_VAR_cache_num_nodes=2
+export TF_VAR_cache_num_nodes=1
 export TF_VAR_cache_param_group="default.redis3.2"
 
 cd ../tf && ./common.sh

--- a/snippets/tokyo/provision.sh
+++ b/snippets/tokyo/provision.sh
@@ -11,8 +11,9 @@ export TF_VAR_alarm_name_stage="Snippets Stage Tokyo"
 ##### Redis config
 export TF_VAR_cache_node_size="cache.m4.xlarge"
 export TF_VAR_cache_port=6379
-export TF_VAR_cache_num_nodes=1
-export TF_VAR_cache_param_group="default.redis3.2"
+export TF_VAR_cache_num_nodes=3
+export TF_VAR_cache_engine_version="2.8.24"
+export TF_VAR_cache_param_group="default.redis2.8"
 
 cd ../tf && ./common.sh
 

--- a/snippets/tokyo/provision.sh
+++ b/snippets/tokyo/provision.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+export SNIPPETS_REGION="ap-northeast-1"
+
+export TF_VAR_region="ap-northeast-1"
+export TF_VAR_region_short="tokyo"
+export TF_VAR_fqdn_prod="snippets-prod.tokyo.moz.works"
+export TF_VAR_fqdn_stage="snippets-stage.tokyo.moz.works"
+export TF_VAR_alarm_name_prod="Snippets Prod Tokyo"
+export TF_VAR_alarm_name_stage="Snippets Stage Tokyo"
+##### Redis config
+export TF_VAR_cache_node_size="cache.m4.xlarge"
+export TF_VAR_cache_port=6379
+export TF_VAR_cache_num_nodes=1
+export TF_VAR_cache_param_group="default.redis3.2"
+
+cd .. && ./common.sh
+

--- a/snippets/tokyo/provision.sh
+++ b/snippets/tokyo/provision.sh
@@ -11,7 +11,7 @@ export TF_VAR_alarm_name_stage="Snippets Stage Tokyo"
 ##### Redis config
 export TF_VAR_cache_node_size="cache.m4.xlarge"
 export TF_VAR_cache_port=6379
-export TF_VAR_cache_num_nodes=1
+export TF_VAR_cache_num_nodes=2
 export TF_VAR_cache_param_group="default.redis3.2"
 
 cd ../tf && ./common.sh


### PR DESCRIPTION
Region and other vars are passed in via environment variables in `./tokyo/provision.sh`. One minor downside is that we have to use underscores in TF variable names, as `-`'s aren't supported in env var names. **Each region maintains it's own state in a shared bucket, under a different path**. See `snippets/common.sh` for details. Snippets TF shared state goes into `s3://snippets-shared-tf-state` in `us-west-2`. 

This is all based on @glogiotatidis's work with modules 🍰 