### PR TITLE
ELB security automation

### DIFF
--- a/elbs/tf/all_elbs.tf
+++ b/elbs/tf/all_elbs.tf
@@ -2,6 +2,66 @@ provider "aws" {
   region = "${var.region}"
 }
 
+# NodePort Security Group
+# shared between all ELB's
+resource "aws_security_group" "elb_to_nodeport" {
+  name        = "elb_to_nodeport"
+  description = "Allow all inbound traffic to reach K8s nodeports"
+  vpc_id      = "${var.vpc_id}"
+}
+
+resource "aws_security_group_rule" "nodeport_ingress" {
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 30000
+  to_port           = 32767
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb_to_nodeport.id}"
+}
+
+resource "aws_security_group_rule" "http_ingress" {
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb_to_nodeport.id}"
+}
+
+resource "aws_security_group_rule" "https_ingress" {
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb_to_nodeport.id}"
+}
+
+resource "aws_security_group_rule" "custom_icmp" {
+  type     = "ingress"
+  protocol = "icmp"
+
+  # https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes-3
+  # ICMP Destination Unreachable
+  from_port = 3
+
+  # Fragmentation Needed and Don't Fragment was Set
+  to_port           = 4
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb_to_nodeport.id}"
+}
+
+resource "aws_security_group_rule" "allow_all_egress" {
+  type              = "egress"
+  protocol          = "all"
+  from_port         = 0
+  to_port           = 65535
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb_to_nodeport.id}"
+}
+
+### ELBS
+
 module "snippets" {
   source                       = "./elbs"
   elb_name                     = "${var.snippets_elb_name}"
@@ -9,6 +69,7 @@ module "snippets" {
   http_listener_instance_port  = "${var.snippets_http_listener_instance_port}"
   https_listener_instance_port = "${var.snippets_https_listener_instance_port}"
   ssl_cert_id                  = "${var.snippets_ssl_cert_id}"
+  security_group_id            = "${aws_security_group.elb_to_nodeport.id}"
 }
 
 module "careers" {
@@ -18,4 +79,5 @@ module "careers" {
   http_listener_instance_port  = "${var.careers_http_listener_instance_port}"
   https_listener_instance_port = "${var.careers_https_listener_instance_port}"
   ssl_cert_id                  = "${var.careers_ssl_cert_id}"
+  security_group_id            = "${aws_security_group.elb_to_nodeport.id}"
 }

--- a/elbs/tf/elbs/elbs.tf
+++ b/elbs/tf/elbs/elbs.tf
@@ -1,6 +1,7 @@
 resource "aws_elb" "new-elb" {
-  name      = "${var.elb_name}"
-  subnets   = ["${split(",", var.subnets)}"]
+  name            = "${var.elb_name}"
+  subnets         = ["${split(",", var.subnets)}"]
+  security_groups = ["${var.security_group_id}"]
 
   listener {
     lb_port           = 80
@@ -21,7 +22,7 @@ resource "aws_elb" "new-elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 6
     timeout             = 5
-    target              = "HTTP:${var.http_listener_instance_port}/"
+    target              = "TCP:${var.http_listener_instance_port}"
     interval            = 10
   }
 

--- a/elbs/tf/elbs/elbs.tf
+++ b/elbs/tf/elbs/elbs.tf
@@ -19,11 +19,11 @@ resource "aws_elb" "new-elb" {
   }
 
   health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 6
-    timeout             = 5
-    target              = "TCP:${var.http_listener_instance_port}"
-    interval            = 10
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    timeout             = "${var.health_check_timeout}"
+    target              = "${var.health_check_target_proto}:${var.http_listener_instance_port}${var.health_check_http_path}"
+    interval            = "${var.health_check_interval}"
   }
 
   cross_zone_load_balancing   = true

--- a/elbs/tf/elbs/variables.tf
+++ b/elbs/tf/elbs/variables.tf
@@ -37,3 +37,30 @@ variable "connection_draining_timeout" {
 }
 
 variable "subnets" {}
+
+variable "health_check_healthy_threshold" {
+  default = 2
+}
+
+variable "health_check_unhealthy_threshold" {
+  default = 6
+}
+
+variable "health_check_timeout" {
+  default = 5
+}
+
+variable "health_check_interval" {
+  default = 10
+}
+
+variable "health_check_target_proto" {
+  default = "HTTP"
+}
+
+variable "health_check_http_path" {
+  # leave empty for tcp healthchecks
+  default = "/"
+}
+
+

--- a/elbs/tf/elbs/variables.tf
+++ b/elbs/tf/elbs/variables.tf
@@ -1,5 +1,7 @@
 variable "elb_name" {}
 
+variable "security_group_id" {}
+
 variable "http_listener_instance_port" {}
 
 variable "http_listener_elb_protocol" {

--- a/elbs/tf/outputs.tf
+++ b/elbs/tf/outputs.tf
@@ -1,0 +1,4 @@
+output "elb_security_group_id" {
+  value = "${aws_security_group.elb_to_nodeport.id}"
+}
+

--- a/elbs/tf/variables.tf
+++ b/elbs/tf/variables.tf
@@ -1,15 +1,26 @@
 variable "region" {}
 
-#snippets
+# general
+variable "vpc_id" {}
+
+# snippets ELB
 variable "snippets_elb_name" {}
+
 variable "snippets_subnets" {}
+
 variable "snippets_http_listener_instance_port" {}
+
 variable "snippets_https_listener_instance_port" {}
+
 variable "snippets_ssl_cert_id" {}
 
-# careers
+# careers ELB
 variable "careers_elb_name" {}
+
 variable "careers_subnets" {}
+
 variable "careers_http_listener_instance_port" {}
+
 variable "careers_https_listener_instance_port" {}
+
 variable "careers_ssl_cert_id" {}

--- a/elbs/virginia/provision.sh
+++ b/elbs/virginia/provision.sh
@@ -2,6 +2,7 @@
 
 export ELB_PROVISIONING_REGION="us-east-1"
 export TF_VAR_region="us-east-1"
+export TF_VAR_vpc_id="vpc-1b35a07d"
 export KOPS_NAME="virginia.moz.works"
 
 # source this file to generate a snippets tfvars file via gen_tf_elb_cfg

--- a/elbs/virginia/provision.sh
+++ b/elbs/virginia/provision.sh
@@ -48,5 +48,4 @@ aws autoscaling attach-load-balancers \
     --load-balancer-names snippets \
     --region "${TF_VAR_region}"
 
-
 attach_nodeport_sg_to_nodes_sg

--- a/elbs/virginia/provision.sh
+++ b/elbs/virginia/provision.sh
@@ -28,6 +28,7 @@ gen_tf_elb_cfg "careers" \
 
 # gen configs from other load balancers here
 
+# Apply Terraform
 cd ../tf && ./common.sh \
     -var-file $SNIPPETS_VARFILE \
     -var-file $CAREERS_VARFILE
@@ -39,10 +40,13 @@ echo "Assigning ELB careers instances from ASG ${ASG_NAME}"
 aws autoscaling attach-load-balancers \
     --auto-scaling-group-name "${ASG_NAME}" \
     --load-balancer-names careers \
-    --region ${TF_VAR_region}
+    --region "${TF_VAR_region}"
 
 echo "Assigning ELB snippets instances from ASG ${ASG_NAME}"
 aws autoscaling attach-load-balancers \
     --auto-scaling-group-name "${ASG_NAME}" \
     --load-balancer-names snippets \
-    --region ${TF_VAR_region}
+    --region "${TF_VAR_region}"
+
+
+attach_nodeport_sg_to_nodes_sg


### PR DESCRIPTION
This PR creates a security group that allows access to the K8s NodePort range. Additionally, there is an ICMP rule that is similar in all K8s generated ELB security groups. This security group is used for each new ELB, and then later applied (outside of TF) to the `nodes.<k8s_cluster>` security group.

- `terraform fmt` applied, sorry for the reformatting noise
- ELB healthcheck fixed to match K8s created healthchecks