### PR TITLE
use TF env's to support multi-region ELB installs

### DIFF
--- a/elbs/tf/.terraform/environment
+++ b/elbs/tf/.terraform/environment
@@ -1,0 +1,1 @@
+virginia

--- a/elbs/tf/.terraform/modules/c372bec9534270600f17ae5e803f2a3b
+++ b/elbs/tf/.terraform/modules/c372bec9534270600f17ae5e803f2a3b
@@ -1,0 +1,1 @@
+/home/admin/infra/elbs/tf/elbs

--- a/elbs/tf/.terraform/modules/e59646bcdd8e4b52e954152f89b5f241
+++ b/elbs/tf/.terraform/modules/e59646bcdd8e4b52e954152f89b5f241
@@ -1,0 +1,1 @@
+/home/admin/infra/elbs/tf/elbs

--- a/elbs/tf/.terraform/terraform.tfstate
+++ b/elbs/tf/.terraform/terraform.tfstate
@@ -1,0 +1,24 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "aa6207c9-deec-4960-a838-11f7997831fd",
+    "backend": {
+        "type": "s3",
+        "config": {
+            "bucket": "elb-provisioning-tf-state",
+            "key": "tf-state",
+            "region": "us-west-2"
+        },
+        "hash": 9584236400188818559
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/elbs/tf/common.sh
+++ b/elbs/tf/common.sh
@@ -3,32 +3,44 @@
 set -e
 set -u
 
-if [ -z "${ELB_PROVISIONING_REGION}" ]; then
-  echo "ELB_PROVISIONING_REGION must be set"
-  exit -1
-fi
+check_prereqs() {
+    if [ -z "${ELB_PROVISIONING_REGION}" ]; then
+    echo "ELB_PROVISIONING_REGION must be set"
+    exit -1
+    fi
+
+
+    if [ -z "${TERRAFORM_ENV}" ]; then
+    echo "TERRAFORM_ENV must be set"
+    exit -1
+    fi
+}
 
 TF_ARGS=$@
 
 ELB_PROVISIONING_BUCKET="elb-provisioning-tf-state"
 STATE_BUCKET_REGION="us-west-2"
 
+check_k8s_context() {
+  current=$(kubectl config current-context)
+  if [ "${current}" != "${KOPS_NAME}" ]; then
+    echo "Please select the appropriate kubeconfig"
+    exit 1
+  fi
+}
+
 setup_tf_s3_state_store() {
     echo "Creating Terraform state bucket at s3://${ELB_PROVISIONING_BUCKET} (region ${STATE_BUCKET_REGION})"
     # The following environment variables are defined in config.sh
     aws s3 mb s3://${ELB_PROVISIONING_BUCKET} --region ${STATE_BUCKET_REGION}
+}
 
-    echo "Configuring Terraform to use an encrypted remote S3 bucket for state storage"
-    # store TF state in S3
-    terraform remote config \
-        -backend=s3 \
-        -backend-config="bucket=${ELB_PROVISIONING_BUCKET}" \
-        -backend-config="key=elb-provisioning-${ELB_PROVISIONING_REGION}/terraform.tfstate" \
-        -backend-config="encrypt=1" \
-        -backend-config="region=${STATE_BUCKET_REGION}"
-
-    echo "Encryption for TF state:"
-    aws s3api head-object --bucket=$ELB_PROVISIONING_BUCKET --key="elb-provisioning-${ELB_PROVISIONING_REGION}/terraform.tfstate" | jq -r .ServerSideEncryption
+setup_tf_envs() {
+    # this MUST be run in the dir that this file resides in
+    set +e
+    terraform env new tokyo
+    terraform env new virginia
+    set -e
 }
 
 check_state_store() {
@@ -39,18 +51,52 @@ check_state_store() {
     else
         echo "Setting up state store"
         setup_tf_s3_state_store
+        echo "Setting up envs"
+        setup_tf_envs
     fi
     set -e
 }
 
+# utils for reimporing resources
+#tf_repair() {
+    #### repairing TF state
+    #terraform refresh $TF_ARGS
+    #
+    # virginia
+    #terraform import aws_security_group.elb_to_nodeport sg-ba095cc5
+    #terraform import module.careers.aws_elb.new-elb careers
+    #terraform import module.snippets.aws_elb.new-elb snippets
+
+    # tokyo
+    #terraform import aws_security_group.elb_to_nodeport sg-ac070bcb
+    #terraform import module.careers.aws_elb.new-elb careers
+    #terraform import module.snippets.aws_elb.new-elb snippets
+    #### end repairing TF state
+#}
+
+tf_main() {
+    # it's safe to always init the s3 backend
+    terraform init
+
+    setup_tf_envs
+
+    # switch env to virginia, tokyo etc
+    terraform env select ${TERRAFORM_ENV}
+
+    # import local modules
+    terraform get
+
+    PLAN=$(mktemp)
+    terraform plan --out $PLAN $TF_ARGS
+    # if terraform plan fails, the next command won't run due to
+    # set -e at the top of the script.
+    terraform apply $PLAN
+    rm $PLAN
+}
+
+check_prereqs
+check_k8s_context
 check_state_store
+tf_main
 
-terraform get
-
-PLAN=$(mktemp)
-terraform plan --out $PLAN $TF_ARGS
-# if terraform plan fails, the next command won't run due to
-# set -e at the top of the script.
-terraform apply $PLAN
-rm $PLAN
 

--- a/elbs/tf/elbs/elbs.tf
+++ b/elbs/tf/elbs/elbs.tf
@@ -22,9 +22,10 @@ resource "aws_elb" "new-elb" {
     healthy_threshold   = "${var.health_check_healthy_threshold}"
     unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
     timeout             = "${var.health_check_timeout}"
+
     # note: using https_listener_instance_port here
-    target              = "${var.health_check_target_proto}:${var.https_listener_instance_port}${var.health_check_http_path}"
-    interval            = "${var.health_check_interval}"
+    target   = "${var.health_check_target_proto}:${var.https_listener_instance_port}${var.health_check_http_path}"
+    interval = "${var.health_check_interval}"
   }
 
   cross_zone_load_balancing   = true

--- a/elbs/tf/elbs/variables.tf
+++ b/elbs/tf/elbs/variables.tf
@@ -62,5 +62,3 @@ variable "health_check_http_path" {
   # leave empty for tcp healthchecks
   default = "/"
 }
-
-

--- a/elbs/tf/outputs.tf
+++ b/elbs/tf/outputs.tf
@@ -1,4 +1,3 @@
 output "elb_security_group_id" {
   value = "${aws_security_group.elb_to_nodeport.id}"
 }
-

--- a/elbs/tokyo/provision.sh
+++ b/elbs/tokyo/provision.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+export TERRAFORM_ENV="tokyo"
 export ELB_PROVISIONING_REGION="ap-northeast-1"
 export TF_VAR_region="ap-northeast-1"
 export TF_VAR_vpc_id="vpc-cd1f99a9"

--- a/elbs/tokyo/snippets-tokyo.tfvars
+++ b/elbs/tokyo/snippets-tokyo.tfvars
@@ -1,0 +1,5 @@
+snippets_elb_name = "snippets"
+snippets_subnets = "subnet-ed79369b"
+snippets_http_listener_instance_port = 30518
+snippets_https_listener_instance_port = 32420
+snippets_ssl_cert_id = "arn:aws:iam::236517346949:server-certificate/snippets.mozilla.com"

--- a/elbs/virginia/provision.sh
+++ b/elbs/virginia/provision.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+export TERRAFORM_ENV="virginia"
 export ELB_PROVISIONING_REGION="us-east-1"
 export TF_VAR_region="us-east-1"
 export TF_VAR_vpc_id="vpc-1b35a07d"


### PR DESCRIPTION
This PR changes the way we store multi-region TF state in S3. 

> NOTE: This functionality requires a new feature of terraform (`terraform env`), available and tested in version `0.9.3`. 

Previously, we were storing TF state in a single bucket in separate directories. However, there were some `terraform.tfstate` files left over in the repo that caused errors when switching regions. When switching regions, running `terraform apply` would report that the `elb_to_nodeport` security group would need to be destroyed and recreated, even though it already existed and didn't need any changes.

This PR uses [`terraform env`](https://www.terraform.io/docs/state/environments.html) to use a single bucket to share state, but with different state filenames. The `elb-provisioning-tf-state` bucket in `us-west-2` contains a directory named `env:` (the name appears to be automatic), with `tokyo` and `virginia` subdirectories storing their respective regions state. I can now run `./provision` in either `./virginia` or `./tokyo` without any issues.

This TF has been applied and virginia and tokyo ELB's are in working order.

Related docs:
- https://www.terraform.io/docs/state/environments.html
- https://www.terraform.io/docs/backends/index.html