### PR TITLE
allow FxA cross account access to basket SQS

### DIFF
--- a/apps/basket/portland/provision.sh
+++ b/apps/basket/portland/provision.sh
@@ -6,6 +6,24 @@ export BASKET_PROVISIONING_REGION="us-west-2"
 # Terraform env
 export TF_VAR_region="${BASKET_PROVISIONING_REGION}"
 
+if [[ -z $TF_VAR_fxa_dev_account ]]; then
+    echo "Please set the TF_VAR_fxa_dev_account value as specified in:"
+    echo "https://bugzilla.mozilla.org/show_bug.cgi?id=1358123#c18"
+    exit 1
+fi
+
+if [[ -z $TF_VAR_fxa_stage_account ]]; then
+    echo "Please set the TF_VAR_fxa_stage_account value as specified in:"
+    echo "https://bugzilla.mozilla.org/show_bug.cgi?id=1358123#c18"
+    exit 1
+fi
+
+if [[ -z $TF_VAR_fxa_prod_account ]]; then
+    echo "Please set the TF_VAR_fxa_prod_account value as specified in:"
+    echo "https://bugzilla.mozilla.org/show_bug.cgi?id=1358123#c18"
+    exit 1
+fi
+
 # Apply Terraform
 cd ../tf && ./common.sh
 

--- a/apps/basket/tf/sqs.tf
+++ b/apps/basket/tf/sqs.tf
@@ -9,3 +9,69 @@ resource "aws_sqs_queue" "basket_delete_queue_stage" {
 resource "aws_sqs_queue" "basket_delete_queue_prod" {
   name = "basket_delete_queue_prod"
 }
+
+
+resource "aws_sqs_queue_policy" "basket_delete_queue_dev_cross_account" {
+  queue_url = "${aws_sqs_queue.basket_delete_queue_dev.id}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ["arn:aws:iam::${var.fxa_dev_account}:root"]
+      },
+      "Action": [
+        "SQS:SendMessage"
+      ],
+      "Resource": "${aws_sqs_queue.basket_delete_queue_dev.arn}"
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "aws_sqs_queue_policy" "basket_delete_queue_stage_cross_account" {
+  queue_url = "${aws_sqs_queue.basket_delete_queue_stage.id}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ["arn:aws:iam::${var.fxa_stage_account}:root"]
+      },
+      "Action": [
+        "SQS:SendMessage"
+      ],
+      "Resource": "${aws_sqs_queue.basket_delete_queue_stage.arn}"
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "aws_sqs_queue_policy" "basket_delete_queue_prod_cross_account" {
+  queue_url = "${aws_sqs_queue.basket_delete_queue_prod.id}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ["arn:aws:iam::${var.fxa_prod_account}:root"]
+      },
+      "Action": [
+        "SQS:SendMessage"
+      ],
+      "Resource": "${aws_sqs_queue.basket_delete_queue_prod.arn}"
+    }
+  ]
+}
+POLICY
+}

--- a/apps/basket/tf/variables.tf
+++ b/apps/basket/tf/variables.tf
@@ -1,1 +1,7 @@
 variable "region" {}
+
+variable "fxa_dev_account" {}
+
+variable "fxa_stage_account" {}
+
+variable "fxa_prod_account" {}


### PR DESCRIPTION
This allows cross AWS account access to the Basket queues per https://bugzilla.mozilla.org/show_bug.cgi?id=1358123#c18

This has already been applied. As the FxA account #'s are private in the ticket, I leave them unpopulated as env vars with a reference to the ticket.