### PR TITLE
Nucleus provisioning

### DIFF
--- a/apps/nucleus/docs/create_apps.md
+++ b/apps/nucleus/docs/create_apps.md
@@ -1,0 +1,26 @@
+# Nucleus app setup
+
+deis2 create nucleus-dev --no-remote
+deis2 create nucleus-stage --no-remote
+deis2 create nucleus-prod --no-remote
+
+deis2 pull quay.io/mozmar/nucleus:3a4dbfe489cc1674742068b38735551711d013e5 -a nucleus-stage
+deis2 pull quay.io/mozmar/nucleus:3a4dbfe489cc1674742068b38735551711d013e5 -a nucleus-prod
+
+deis2 limits:set web=150M/300M -a nucleus-stage
+deis2 limits:set web=100m/250m --cpu -a nucleus-stage
+deis2 autoscale:set web --min=3 --max=5 --cpu-percent=80 -a nucleus-stage
+
+deis2 limits:set web=150M/300M -a nucleus-prod
+deis2 limits:set web=100m/250m --cpu -a nucleus-prod
+deis2 autoscale:set cmd --min=3 --max=5 --cpu-percent=80 -a nucleus-prod
+
+deis2 config:unset SECURE_SSL_REDIRECT -a nucleus-stage
+deis2 config:unset SECURE_SSL_REDIRECT -a nucleus-prod
+
+deis2 config:set  SSL_DISABLE=True -a nucleus-stage
+deis2 config:set  SSL_DISABLE=True -a nucleus-prod
+
+deis2 config:set ALLOWED_HOSTS=\* -a nucleus-stage
+deis2 config:set ALLOWED_HOSTS=\* -a nucleus-prod
+

--- a/apps/nucleus/docs/create_databases.md
+++ b/apps/nucleus/docs/create_databases.md
@@ -1,0 +1,43 @@
+# Nucleus Postgres setup
+
+For each RDS instance, you'll need to connect to Postgres via K8s:
+
+```
+# if you don't have your own K8s namespace, you can easily create one with:
+kubectl create namespace your_namespace
+# replacing your_namespace with whatever you like
+
+# next, start a postgres pod to use the psql client:
+kubectl -n your_namespace run -i -t pgsql --image=postgres -- bash
+psql -h some_url -U bedrock
+```
+
+Once you've connected to Postgres, run the following script with `[REDACTED]` replaced with appropriate passwords:
+
+```
+create role nucleus_dev;
+create role nucleus_stage;
+create role nucleus_prod;
+
+create database nucleus_dev;
+create database nucleus_stage;
+create database nucleus_prod;
+
+alter database nucleus_dev owner to nucleus_dev ;
+alter database nucleus_stage owner to nucleus_stage;
+alter database nucleus_prod owner to nucleus_prod;
+
+alter role nucleus_dev with password '[REDACTED]';
+alter role nucleus_stage with password '[REDACTED]';
+alter role nucleus_prod with password '[REDACTED]';
+
+alter role nucleus_dev login;
+alter role nucleus_stage login;
+alter role nucleus_prod login;
+```
+
+Cleanup when you're finished:
+
+```
+kubectl -n your_namespace delete deployment pgsql
+```

--- a/apps/nucleus/k8s/nucleus-prod-nodeport.yaml
+++ b/apps/nucleus/k8s/nucleus-prod-nodeport.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    app: nucleus-prod
+  name: nucleus-nodeport
+  namespace: nucleus-prod
+spec:
+  type: NodePort
+  selector:
+    app: nucleus-prod
+    type: cmd
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000

--- a/apps/nucleus/k8s/nucleus-stage-nodeport.yaml
+++ b/apps/nucleus/k8s/nucleus-stage-nodeport.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    app: nucleus-stage
+  name: nucleus-nodeport
+  namespace: nucleus-stage
+spec:
+  type: NodePort
+  selector:
+    app: nucleus-stage
+    type: cmd
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+

--- a/elbs/tf/all_elbs.tf
+++ b/elbs/tf/all_elbs.tf
@@ -126,3 +126,20 @@ module "wilcard-allizom" {
   # leave path empty!
   health_check_http_path      = ""
 }
+
+module "nucleus-prod" {
+  # if the nucleus-elbs-by-region map contains the current region, then
+  # set elb_count to 1, otherwise, default to 0.
+  # A value of 1 will create an ELB, a value of 0 won't.
+  # NOTE: we still need to pass in dummy values for the variables below
+  # when we aren't creating an ELB to allow TF to run
+  elb_count = "${lookup(var.nucleus-elbs-by-region, var.region, 0)}"
+  source                       = "./elbs"
+  elb_name                     = "${var.nucleus-prod_elb_name}"
+  subnets                      = "${var.nucleus-prod_subnets}"
+  http_listener_instance_port  = "${var.nucleus-prod_http_listener_instance_port}"
+  https_listener_instance_port = "${var.nucleus-prod_https_listener_instance_port}"
+  ssl_cert_id                  = "${var.nucleus-prod_ssl_cert_id}"
+  security_group_id            = "${aws_security_group.elb_to_nodeport.id}"
+  health_check_http_path       = "/"
+}

--- a/elbs/tf/elb_utils.sh
+++ b/elbs/tf/elb_utils.sh
@@ -24,6 +24,12 @@ get_https_nodeport() {
     get_nodeport "https" $NAMESPACE $NODEPORT_SERVICE
 }
 
+get_http_nodeport() {
+    NAMESPACE=$1
+    NODEPORT_SERVICE=$2
+    get_nodeport "http" $NAMESPACE $NODEPORT_SERVICE
+}
+
 get_nodeport() {
     PROTO=$1
     NAMESPACE=$2
@@ -38,9 +44,14 @@ gen_tf_elb_cfg() {
     NODEPORT_SERVICE=$3
     VPC_SUBNETS=$4
     SSL_CERT_ID=$5
+    NODEPORT_PROTO="${6:-https}"
 
     HTTP_PORT=$(get_redirector_port)
-    HTTPS_PORT=$(get_https_nodeport ${NAMESPACE} ${NODEPORT_SERVICE})
+    if [ "$NODEPORT_PROTO" == "https" ]; then
+      HTTPS_PORT=$(get_https_nodeport ${NAMESPACE} ${NODEPORT_SERVICE})
+    elif [ "$NODEPORT_PROTO" == "http" ]; then
+      HTTPS_PORT=$(get_http_nodeport ${NAMESPACE} ${NODEPORT_SERVICE})
+    fi
 
     cat <<EOF
 ${ELB_NAME}_elb_name = "${ELB_NAME}"

--- a/elbs/tf/elbs/elbs.tf
+++ b/elbs/tf/elbs/elbs.tf
@@ -1,4 +1,5 @@
 resource "aws_elb" "new-elb" {
+  count           = "${var.elb_count}"
   name            = "${var.elb_name}"
   subnets         = ["${split(",", var.subnets)}"]
   security_groups = ["${var.security_group_id}"]

--- a/elbs/tf/elbs/variables.tf
+++ b/elbs/tf/elbs/variables.tf
@@ -1,5 +1,9 @@
 variable "elb_name" {}
 
+variable "elb_count" {
+  default = 1
+}
+
 variable "security_group_id" {}
 
 variable "http_listener_instance_port" {}

--- a/elbs/tf/variables.tf
+++ b/elbs/tf/variables.tf
@@ -71,3 +71,22 @@ variable "wildcard-allizom_https_listener_instance_port" {}
 
 variable "wildcard-allizom_ssl_cert_id" {}
 
+
+# nucleus-prod ELB
+variable "nucleus-prod_elb_name" {}
+
+variable "nucleus-prod_subnets" {}
+
+variable "nucleus-prod_http_listener_instance_port" {}
+
+variable "nucleus-prod_https_listener_instance_port" {}
+
+variable "nucleus-prod_ssl_cert_id" {}
+
+
+variable "nucleus-elbs-by-region" {
+  type = "map"
+  default = {
+    "us-east-1" = true
+  }
+}

--- a/elbs/tokyo/nucleus-prod-virginia.tfvars
+++ b/elbs/tokyo/nucleus-prod-virginia.tfvars
@@ -1,0 +1,5 @@
+nucleus-prod_elb_name = ""
+nucleus-prod_subnets = ""
+nucleus-prod_http_listener_instance_port = 0
+nucleus-prod_https_listener_instance_port = 0
+nucleus-prod_ssl_cert_id = ""

--- a/elbs/tokyo/provision.sh
+++ b/elbs/tokyo/provision.sh
@@ -17,6 +17,8 @@ BEDROCK_STAGE_VARFILE=$(pwd)/bedrock-stage-tokyo.tfvars
 BEDROCK_PROD_VARFILE=$(pwd)/bedrock-prod-tokyo.tfvars
 WILCARD_ALLIZOM_VARFILE=$(pwd)/wildcard-allizom-tokyo.tfvars
 
+NUCLEUS_PROD_VARFILE=$(pwd)/nucleus-prod-virginia.tfvars
+
 TOKYO_SUBNETS="subnet-ed79369b"
 # param order: elb name, namespace, nodeport service name, subnets
 gen_tf_elb_cfg "snippets" \
@@ -58,13 +60,16 @@ gen_tf_elb_cfg "wildcard-allizom" \
 # gen configs from other load balancers here
 
 # Apply Terraform
+# NOTE: we're passing in dummy values for nucleus prod as Terraform needs 
+#       them set, even though we're not creating a nucleus prod elb in Tokyo
 cd ../tf && ./common.sh \
     -var-file $SNIPPETS_VARFILE \
     -var-file $SNIPPETS_STATS_VARFILE \
     -var-file $CAREERS_VARFILE \
     -var-file $BEDROCK_PROD_VARFILE \
     -var-file $BEDROCK_STAGE_VARFILE \
-    -var-file $WILCARD_ALLIZOM_VARFILE
+    -var-file $WILCARD_ALLIZOM_VARFILE \
+    -var-file $NUCLEUS_PROD_VARFILE
 
 # attach each ELB to the k8s nodes ASG
 ASG_NAME="nodes.${KOPS_NAME}"

--- a/elbs/virginia/nucleus-prod-virginia.tfvars
+++ b/elbs/virginia/nucleus-prod-virginia.tfvars
@@ -1,0 +1,5 @@
+nucleus-prod_elb_name = "nucleus-prod"
+nucleus-prod_subnets = "subnet-43125f6e,subnet-a699aaef,subnet-b6ceb6ed"
+nucleus-prod_http_listener_instance_port = 30267
+nucleus-prod_https_listener_instance_port = 30458
+nucleus-prod_ssl_cert_id = "arn:aws:acm:us-east-1:236517346949:certificate/fa2f75df-e710-4e2a-b210-2647c4179dac"

--- a/elbs/virginia/wildcard-allizom-virginia.tfvars
+++ b/elbs/virginia/wildcard-allizom-virginia.tfvars
@@ -1,0 +1,5 @@
+wildcard-allizom_elb_name = "wildcard-allizom"
+wildcard-allizom_subnets = "subnet-43125f6e,subnet-a699aaef,subnet-b6ceb6ed"
+wildcard-allizom_http_listener_instance_port = 30267
+wildcard-allizom_https_listener_instance_port = 31569
+wildcard-allizom_ssl_cert_id = "arn:aws:iam::236517346949:server-certificate/wildcard.allizom.org_20180103"


### PR DESCRIPTION
`elbs/tf/variables.tf` contains a Terraform map called `nucleus-elbs-by-region`, which allows us to only create a nucleus elb in regions specified. I use this to skip Tokyo.

Note: I added `elbs/virginia/wildcard-allizom-virginia.tfvars` in this PR, even though it's not related to nucleus. It's not going to break anything if it's missing, but it can make tracking ELB changes in the future a little bit easier.