### PR TITLE
change allizom cert

### DIFF
--- a/elbs/virginia/bedrock-stage-virginia.tfvars
+++ b/elbs/virginia/bedrock-stage-virginia.tfvars
@@ -2,4 +2,4 @@ bedrock-stage_elb_name = "bedrock-stage"
 bedrock-stage_subnets = "subnet-43125f6e,subnet-a699aaef,subnet-b6ceb6ed"
 bedrock-stage_http_listener_instance_port = 30267
 bedrock-stage_https_listener_instance_port = 30498
-bedrock-stage_ssl_cert_id = "arn:aws:acm:us-east-1:236517346949:certificate/ecb993c5-e2e5-4864-9509-855aaafec0c9"
+bedrock-stage_ssl_cert_id = "arn:aws:acm:us-east-1:236517346949:certificate/50b07528-991c-449c-bb0d-537307a981e9"

--- a/elbs/virginia/provision.sh
+++ b/elbs/virginia/provision.sh
@@ -46,7 +46,7 @@ gen_tf_elb_cfg "bedrock-stage" \
                "bedrock-stage" \
                "bedrock-nodeport" \
                "${VIRGINIA_SUBNETS}" \
-               "arn:aws:acm:us-east-1:236517346949:certificate/ecb993c5-e2e5-4864-9509-855aaafec0c9" > $BEDROCK_STAGE_VARFILE
+               "arn:aws:acm:us-east-1:236517346949:certificate/50b07528-991c-449c-bb0d-537307a981e9" > $BEDROCK_STAGE_VARFILE
 
 gen_tf_elb_cfg "bedrock-prod" \
                "bedrock-prod" \


### PR DESCRIPTION
this PR uses a new allizom cert that has an additional SAN for `bedrock-stage.moz.works`.