### PR TITLE
cleanup to allow k8s 1.6.4, helm 2.4.2, kops 1.6.1

### DIFF
--- a/k8s/install/etc/deis_s3.tf.template
+++ b/k8s/install/etc/deis_s3.tf.template
@@ -82,7 +82,7 @@ output "registry-bucket" {
   value = "${var.registry-bucket-name}"
 }
 
-output "region" {
+output "s3-region" {
   value = "KOPS_REGION"
 }
 

--- a/k8s/install/stage2_functions.sh
+++ b/k8s/install/stage2_functions.sh
@@ -147,7 +147,6 @@ customize_workflow() {
     # write to a temp file first
     cp ./workflow/patched_requirements.yaml ./workflow/requirements.yaml
 
-
     # SSL is handled at the ELB, but the ELB still wants to point to the Deis router SSL
     # port internally. We change the ssl port to be unencrypted (http) internally.
     # TODO: use a template with condition and submit upstream

--- a/k8s/install/stage2_functions.sh
+++ b/k8s/install/stage2_functions.sh
@@ -76,7 +76,7 @@ install_dd() {
     echo "Installing Datadog"
     kubectl create namespace datadog | true
     kubectl create -f ${STAGE2_ETC_PATH}/dd-agent.yaml
-    kubectl create -f etc/datadog_statsd_svc.yaml
+    kubectl create -f ${KOPS_INSTALLER}/etc/datadog_statsd_svc.yaml
 }
 
 install_newrelic() {

--- a/k8s/install/stage2_functions.sh
+++ b/k8s/install/stage2_functions.sh
@@ -151,8 +151,6 @@ customize_workflow() {
     # port internally. We change the ssl port to be unencrypted (http) internally.
     # TODO: use a template with condition and submit upstream
     sed -i "s/6443/8080/" workflow/charts/router/templates/router-service.yaml
-
-
     echo "Workflow customized"
 }
 


### PR DESCRIPTION
- k8s 1.6.4 master wouldn't start w/ `kops` 1.5.1, so I upgraded to 1.6.1 
- new clusters MUST use kubectl >= 1.6.4
- kops tf generates an output named `region` that we were already using 
  - renamed our output to `s3-region`
- the newest kops supports [setting master/node volume sizes](https://github.com/kubernetes/kops/pull/2684/files)
- terraform encrypted S3 state store is easier to setup via `terraform init`
   - the old method has been removed from the `terraform` cmd, which breaks our install scripts.
- the newer `helm` command is more strict about `requirements.yaml`, which now has to be patched to remove the components that we've removed from Deis in the `customize_workflow` function.