### PR TITLE
fix irlpodcast subdir index issue

### DIFF
--- a/apps/irlpodcast/tf/irlpodcast.tf
+++ b/apps/irlpodcast/tf/irlpodcast.tf
@@ -81,7 +81,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
       http_port = "80"
       https_port = "443"
       origin_ssl_protocols = ["TLSv1"]
-      #origin_read_timeout = 4
     }
   }
 

--- a/apps/irlpodcast/tf/irlpodcast.tf
+++ b/apps/irlpodcast/tf/irlpodcast.tf
@@ -74,8 +74,15 @@ EOF
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = "${aws_s3_bucket.irlpodcast.bucket_domain_name}"
+    domain_name = "irlpodcast.s3-website-us-west-2.amazonaws.com"
     origin_id   = "IRLPodcast"
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      http_port = "80"
+      https_port = "443"
+      origin_ssl_protocols = ["TLSv1"]
+      #origin_read_timeout = 4
+    }
   }
 
   enabled             = true


### PR DESCRIPTION
fixes https://github.com/mozmar/infra/issues/289
changes have already been applied.

Use an s3 website bucket name so index documents work in subdirs.

The custom_origin_config is required because terraform will insist that the bucket name is incorrect as it doesn't follow the irlpodcast.s3.amazonaws.com format.

**requires terraform 0.9.8**

see also:
https://github.com/hashicorp/terraform/issues/10572
https://github.com/hashicorp/terraform/issues/13627

