### PR TITLE
cloudfront to origin uses http

### DIFF
--- a/apps/irlpodcast/tf/irlpodcast.tf
+++ b/apps/irlpodcast/tf/irlpodcast.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     domain_name = "irlpodcast.s3-website-us-west-2.amazonaws.com"
     origin_id   = "IRLPodcast"
     custom_origin_config {
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       http_port = "80"
       https_port = "443"
       origin_ssl_protocols = ["TLSv1"]


### PR DESCRIPTION
The S3 website bucket `irlpodcast.s3-website-us-west-2.amazonaws.com` apparently doesn't listen on 443. Note that this setting is for CloudFront to S3 communications. If a user goes to http://irlpodcast.org, they'll be redirected to https://irlpodcast.org

See also: https://github.com/mozmar/infra/pull/302
